### PR TITLE
fix: unify preemptible attributes

### DIFF
--- a/inputs/templates/maxquant/config-maxquant.json
+++ b/inputs/templates/maxquant/config-maxquant.json
@@ -5,6 +5,7 @@
   "proteomics_maxquant.mq_disk": 500,
   "proteomics_maxquant.mq_docker": "docker-repository/maxquant:v1660",
   "proteomics_maxquant.mq_parameters": "gcp-parameters",
-  "proteomics_maxquant.mq_ramGB": 380
+  "proteomics_maxquant.mq_ramGB": 380,
+  "proteomics_maxquant.num_preemptible_attempts": 2
 }
 

--- a/inputs/templates/msgfplus/config-msgfplus-ac-lf.json
+++ b/inputs/templates/msgfplus/config-msgfplus-ac-lf.json
@@ -44,10 +44,5 @@
   "proteomics_msgfplus.wrapper_docker": "docker-repository/plexedpiper:v0.4.1",
   "proteomics_msgfplus.wrapper_ncpu": 8,
   "proteomics_msgfplus.wrapper_ramGB": 60,
-  "proteomics_msgfplus.masic_preemptible": 2,
-  "proteomics_msgfplus.msconvert_preemptible": 2,
-  "proteomics_msgfplus.msgf_preemptible": 2,
-  "proteomics_msgfplus.phrp_preemptible": 2,
-  "proteomics_msgfplus.ascore_preemptible": 2,
-  "proteomics_msgfplus.wrapper_preemptible": 2
+  "proteomics_msgfplus.num_preemptible_attempts": 2
 }

--- a/inputs/templates/msgfplus/config-msgfplus-ac-tmt11.json
+++ b/inputs/templates/msgfplus/config-msgfplus-ac-tmt11.json
@@ -47,10 +47,5 @@
   "proteomics_msgfplus.refine_prior": true,
   "proteomics_msgfplus.sequence_db_name": "String",
   "proteomics_msgfplus.unique_only": false,
-  "proteomics_msgfplus.masic_preemptible": 2,
-  "proteomics_msgfplus.msconvert_preemptible": 2,
-  "proteomics_msgfplus.msgf_preemptible": 2,
-  "proteomics_msgfplus.phrp_preemptible": 2,
-  "proteomics_msgfplus.ascore_preemptible": 2,
-  "proteomics_msgfplus.wrapper_preemptible": 2
+  "proteomics_msgfplus.num_preemptible_attempts": 2
 }

--- a/inputs/templates/msgfplus/config-msgfplus-ac-tmt16.json
+++ b/inputs/templates/msgfplus/config-msgfplus-ac-tmt16.json
@@ -47,10 +47,5 @@
   "proteomics_msgfplus.refine_prior": true,
   "proteomics_msgfplus.sequence_db_name": "String",
   "proteomics_msgfplus.unique_only": false,
-  "proteomics_msgfplus.masic_preemptible": 2,
-  "proteomics_msgfplus.msconvert_preemptible": 2,
-  "proteomics_msgfplus.msgf_preemptible": 2,
-  "proteomics_msgfplus.phrp_preemptible": 2,
-  "proteomics_msgfplus.ascore_preemptible": 2,
-  "proteomics_msgfplus.wrapper_preemptible": 2
+  "proteomics_msgfplus.num_preemptible_attempts": 2
 }

--- a/inputs/templates/msgfplus/config-msgfplus-ac-tmt18.json
+++ b/inputs/templates/msgfplus/config-msgfplus-ac-tmt18.json
@@ -47,10 +47,5 @@
   "proteomics_msgfplus.refine_prior": true,
   "proteomics_msgfplus.sequence_db_name": "String",
   "proteomics_msgfplus.unique_only": false,
-  "proteomics_msgfplus.masic_preemptible": 2,
-  "proteomics_msgfplus.msconvert_preemptible": 2,
-  "proteomics_msgfplus.msgf_preemptible": 2,
-  "proteomics_msgfplus.phrp_preemptible": 2,
-  "proteomics_msgfplus.ascore_preemptible": 2,
-  "proteomics_msgfplus.wrapper_preemptible": 2
+  "proteomics_msgfplus.num_preemptible_attempts": 2
 }

--- a/inputs/templates/msgfplus/config-msgfplus-ph-lf.json
+++ b/inputs/templates/msgfplus/config-msgfplus-ph-lf.json
@@ -44,10 +44,5 @@
   "proteomics_msgfplus.wrapper_docker": "docker-repository/plexedpiper:v0.4.1",
   "proteomics_msgfplus.wrapper_ncpu": 8,
   "proteomics_msgfplus.wrapper_ramGB": 60,
-  "proteomics_msgfplus.masic_preemptible": 2,
-  "proteomics_msgfplus.msconvert_preemptible": 2,
-  "proteomics_msgfplus.msgf_preemptible": 2,
-  "proteomics_msgfplus.phrp_preemptible": 2,
-  "proteomics_msgfplus.ascore_preemptible": 2,
-  "proteomics_msgfplus.wrapper_preemptible": 2
+  "proteomics_msgfplus.num_preemptible_attempts": 2
 }

--- a/inputs/templates/msgfplus/config-msgfplus-ph-tmt11.json
+++ b/inputs/templates/msgfplus/config-msgfplus-ph-tmt11.json
@@ -47,10 +47,5 @@
   "proteomics_msgfplus.refine_prior": true,
   "proteomics_msgfplus.sequence_db_name": "String",
   "proteomics_msgfplus.unique_only": false,
-  "proteomics_msgfplus.masic_preemptible": 2,
-  "proteomics_msgfplus.msconvert_preemptible": 2,
-  "proteomics_msgfplus.msgf_preemptible": 2,
-  "proteomics_msgfplus.phrp_preemptible": 2,
-  "proteomics_msgfplus.ascore_preemptible": 2,
-  "proteomics_msgfplus.wrapper_preemptible": 2
+  "proteomics_msgfplus.num_preemptible_attempts": 2
 }

--- a/inputs/templates/msgfplus/config-msgfplus-ph-tmt16.json
+++ b/inputs/templates/msgfplus/config-msgfplus-ph-tmt16.json
@@ -47,10 +47,5 @@
   "proteomics_msgfplus.refine_prior": true,
   "proteomics_msgfplus.sequence_db_name": "String",
   "proteomics_msgfplus.unique_only": false,
-  "proteomics_msgfplus.masic_preemptible": 2,
-  "proteomics_msgfplus.msconvert_preemptible": 2,
-  "proteomics_msgfplus.msgf_preemptible": 2,
-  "proteomics_msgfplus.phrp_preemptible": 2,
-  "proteomics_msgfplus.ascore_preemptible": 2,
-  "proteomics_msgfplus.wrapper_preemptible": 2
+  "proteomics_msgfplus.num_preemptible_attempts": 2
 }

--- a/inputs/templates/msgfplus/config-msgfplus-ph-tmt18.json
+++ b/inputs/templates/msgfplus/config-msgfplus-ph-tmt18.json
@@ -47,10 +47,5 @@
   "proteomics_msgfplus.refine_prior": true,
   "proteomics_msgfplus.sequence_db_name": "String",
   "proteomics_msgfplus.unique_only": false,
-  "proteomics_msgfplus.masic_preemptible": 2,
-  "proteomics_msgfplus.msconvert_preemptible": 2,
-  "proteomics_msgfplus.msgf_preemptible": 2,
-  "proteomics_msgfplus.phrp_preemptible": 2,
-  "proteomics_msgfplus.ascore_preemptible": 2,
-  "proteomics_msgfplus.wrapper_preemptible": 2
+  "proteomics_msgfplus.num_preemptible_attempts": 2
 }

--- a/inputs/templates/msgfplus/config-msgfplus-pr-lf.json
+++ b/inputs/templates/msgfplus/config-msgfplus-pr-lf.json
@@ -36,10 +36,5 @@
   "proteomics_msgfplus.wrapper_docker": "docker-repository/plexedpiper:v0.4.1",
   "proteomics_msgfplus.wrapper_ncpu": 8,
   "proteomics_msgfplus.wrapper_ramGB": 60,
-  "proteomics_msgfplus.masic_preemptible": 2,
-  "proteomics_msgfplus.msconvert_preemptible": 2,
-  "proteomics_msgfplus.msgf_preemptible": 2,
-  "proteomics_msgfplus.phrp_preemptible": 2,
-  "proteomics_msgfplus.ascore_preemptible": 2,
-  "proteomics_msgfplus.wrapper_preemptible": 2
+  "proteomics_msgfplus.num_preemptible_attempts": 2
 }

--- a/inputs/templates/msgfplus/config-msgfplus-pr-tmt11.json
+++ b/inputs/templates/msgfplus/config-msgfplus-pr-tmt11.json
@@ -41,10 +41,5 @@
   "proteomics_msgfplus.refine_prior": true,
   "proteomics_msgfplus.sequence_db_name": "String",
   "proteomics_msgfplus.unique_only": false,
-  "proteomics_msgfplus.masic_preemptible": 2,
-  "proteomics_msgfplus.msconvert_preemptible": 2,
-  "proteomics_msgfplus.msgf_preemptible": 2,
-  "proteomics_msgfplus.phrp_preemptible": 2,
-  "proteomics_msgfplus.ascore_preemptible": 2,
-  "proteomics_msgfplus.wrapper_preemptible": 2
+  "proteomics_msgfplus.num_preemptible_attempts": 2
 }

--- a/inputs/templates/msgfplus/config-msgfplus-pr-tmt16.json
+++ b/inputs/templates/msgfplus/config-msgfplus-pr-tmt16.json
@@ -41,10 +41,5 @@
   "proteomics_msgfplus.refine_prior": true,
   "proteomics_msgfplus.sequence_db_name": "String",
   "proteomics_msgfplus.unique_only": false,
-  "proteomics_msgfplus.masic_preemptible": 2,
-  "proteomics_msgfplus.msconvert_preemptible": 2,
-  "proteomics_msgfplus.msgf_preemptible": 2,
-  "proteomics_msgfplus.phrp_preemptible": 2,
-  "proteomics_msgfplus.ascore_preemptible": 2,
-  "proteomics_msgfplus.wrapper_preemptible": 2
+  "proteomics_msgfplus.num_preemptible_attempts": 2
 }

--- a/inputs/templates/msgfplus/config-msgfplus-pr-tmt18.json
+++ b/inputs/templates/msgfplus/config-msgfplus-pr-tmt18.json
@@ -41,10 +41,5 @@
   "proteomics_msgfplus.refine_prior": true,
   "proteomics_msgfplus.sequence_db_name": "String",
   "proteomics_msgfplus.unique_only": false,
-  "proteomics_msgfplus.masic_preemptible": 2,
-  "proteomics_msgfplus.msconvert_preemptible": 2,
-  "proteomics_msgfplus.msgf_preemptible": 2,
-  "proteomics_msgfplus.phrp_preemptible": 2,
-  "proteomics_msgfplus.ascore_preemptible": 2,
-  "proteomics_msgfplus.wrapper_preemptible": 2
+  "proteomics_msgfplus.num_preemptible_attempts": 2
 }

--- a/inputs/templates/msgfplus/config-msgfplus-ub-lf.json
+++ b/inputs/templates/msgfplus/config-msgfplus-ub-lf.json
@@ -44,10 +44,5 @@
   "proteomics_msgfplus.wrapper_docker": "docker-repository/plexedpiper:v0.4.1",
   "proteomics_msgfplus.wrapper_ncpu": 8,
   "proteomics_msgfplus.wrapper_ramGB": 60,
-  "proteomics_msgfplus.masic_preemptible": 2,
-  "proteomics_msgfplus.msconvert_preemptible": 2,
-  "proteomics_msgfplus.msgf_preemptible": 2,
-  "proteomics_msgfplus.phrp_preemptible": 2,
-  "proteomics_msgfplus.ascore_preemptible": 2,
-  "proteomics_msgfplus.wrapper_preemptible": 2
+  "proteomics_msgfplus.num_preemptible_attempts": 2
 }

--- a/inputs/templates/msgfplus/config-msgfplus-ub-tmt11.json
+++ b/inputs/templates/msgfplus/config-msgfplus-ub-tmt11.json
@@ -47,10 +47,5 @@
   "proteomics_msgfplus.refine_prior": true,
   "proteomics_msgfplus.sequence_db_name": "String",
   "proteomics_msgfplus.unique_only": false,
-  "proteomics_msgfplus.masic_preemptible": 2,
-  "proteomics_msgfplus.msconvert_preemptible": 2,
-  "proteomics_msgfplus.msgf_preemptible": 2,
-  "proteomics_msgfplus.phrp_preemptible": 2,
-  "proteomics_msgfplus.ascore_preemptible": 2,
-  "proteomics_msgfplus.wrapper_preemptible": 2
+  "proteomics_msgfplus.num_preemptible_attempts": 2
 }

--- a/inputs/templates/msgfplus/config-msgfplus-ub-tmt16.json
+++ b/inputs/templates/msgfplus/config-msgfplus-ub-tmt16.json
@@ -47,10 +47,5 @@
   "proteomics_msgfplus.refine_prior": true,
   "proteomics_msgfplus.sequence_db_name": "String",
   "proteomics_msgfplus.unique_only": false,
-  "proteomics_msgfplus.masic_preemptible": 2,
-  "proteomics_msgfplus.msconvert_preemptible": 2,
-  "proteomics_msgfplus.msgf_preemptible": 2,
-  "proteomics_msgfplus.phrp_preemptible": 2,
-  "proteomics_msgfplus.ascore_preemptible": 2,
-  "proteomics_msgfplus.wrapper_preemptible": 2
+  "proteomics_msgfplus.num_preemptible_attempts": 2
 }

--- a/inputs/templates/msgfplus/config-msgfplus-ub-tmt18.json
+++ b/inputs/templates/msgfplus/config-msgfplus-ub-tmt18.json
@@ -47,10 +47,5 @@
   "proteomics_msgfplus.refine_prior": true,
   "proteomics_msgfplus.sequence_db_name": "String",
   "proteomics_msgfplus.unique_only": false,
-  "proteomics_msgfplus.masic_preemptible": 2,
-  "proteomics_msgfplus.msconvert_preemptible": 2,
-  "proteomics_msgfplus.msgf_preemptible": 2,
-  "proteomics_msgfplus.phrp_preemptible": 2,
-  "proteomics_msgfplus.ascore_preemptible": 2,
-  "proteomics_msgfplus.wrapper_preemptible": 2
+  "proteomics_msgfplus.num_preemptible_attempts": 2
 }

--- a/wdl/proteomics_maxquant.wdl
+++ b/wdl/proteomics_maxquant.wdl
@@ -25,6 +25,7 @@ workflow proteomics_maxquant {
         Int mq_ramGB
         Int? mq_disk
         String mq_docker
+        Int num_preemptible_attempts = 2
     }
 
     call maxquant {
@@ -35,7 +36,8 @@ workflow proteomics_maxquant {
             disks = mq_disk,
             mq_parameters = mq_parameters,
             fasta_sequence_db = fasta_sequence_db,
-            raw_file = raw_file
+            raw_file = raw_file,
+            preemptible = num_preemptible_attempts
     }
 }
 
@@ -45,6 +47,7 @@ task maxquant {
         Int ramGB
         Int? disks
         String docker
+        Int preemptible
         File mq_parameters
         File fasta_sequence_db
         Array[File] raw_file
@@ -97,10 +100,11 @@ task maxquant {
     }
 
     runtime {
-        docker: "${docker}"
+        cpu: ncpu
         memory: "${ramGB} GB"
-        cpu: "${ncpu}"
         disks: "local-disk ${select_first([disks, 100])} HDD"
+        docker: "${docker}"
+        preemptible: preemptible
     }
     
     parameter_meta {

--- a/wdl/proteomics_msgfplus.wdl
+++ b/wdl/proteomics_msgfplus.wdl
@@ -53,7 +53,10 @@ workflow proteomics_msgfplus {
         }
     }
 
-    input {    # Quantification method
+    input {
+        Int num_preemptible_attempts = 2
+
+        # Quantification method
         String quant_method
 
         # RAW INPUT FILES
@@ -66,7 +69,6 @@ workflow proteomics_msgfplus {
         Int masic_ramGB
         String masic_docker
         Int? masic_disk
-        Int masic_preemptible = 2
         File masic_parameter
 
         # MSCONVERT
@@ -74,14 +76,12 @@ workflow proteomics_msgfplus {
         Int msconvert_ramGB
         String msconvert_docker
         Int? msconvert_disk
-        Int msconvert_preemptible = 2
 
         # MS-GF+ SHARED OPTIONS
         Int msgf_ncpu
         Int msgf_ramGB
         String msgf_docker
         Int? msgf_disk
-        Int msgf_preemptible = 2
         File fasta_sequence_db
         String sequence_db_name
 
@@ -102,7 +102,6 @@ workflow proteomics_msgfplus {
         Int phrp_ramGB
         String phrp_docker
         Int? phrp_disk
-        Int phrp_preemptible = 2
 
         File phrp_parameter_m
         File phrp_parameter_t
@@ -116,7 +115,6 @@ workflow proteomics_msgfplus {
         Int? ascore_ramGB
         String? ascore_docker
         Int? ascore_disk
-        Int? ascore_preemptible = 2
         File? ascore_parameter_p
 
         # WRAPPER (PlexedPiper)
@@ -124,7 +122,6 @@ workflow proteomics_msgfplus {
         Int? wrapper_ramGB
         String? wrapper_docker
         Int? wrapper_disk
-        Int? wrapper_preemptible = 2
         File? sd_fractions
         File? sd_references
         File? sd_samples
@@ -142,7 +139,7 @@ workflow proteomics_msgfplus {
             docker = msgf_docker,
             disks = msgf_disk,
             fasta_sequence_db = fasta_sequence_db,
-            preemptible = msgf_preemptible
+            preemptible = num_preemptible_attempts
     }
 
     scatter (i in range(length(raw_file))) {
@@ -152,7 +149,7 @@ workflow proteomics_msgfplus {
                 ramGB = masic_ramGB,
                 docker = masic_docker,
                 disks = masic_disk,
-                preemptible = masic_preemptible,
+                preemptible = num_preemptible_attempts,
                 raw_file = raw_file[i],
                 masic_parameter = masic_parameter,
                 quant_method = quant_method
@@ -164,7 +161,7 @@ workflow proteomics_msgfplus {
                 ramGB = msconvert_ramGB,
                 docker = msconvert_docker,
                 disks = msconvert_disk,
-                preemptible = msconvert_preemptible,
+                preemptible = num_preemptible_attempts,
                 raw_file = raw_file[i]
         }
 
@@ -174,7 +171,7 @@ workflow proteomics_msgfplus {
                 ramGB = msgf_ramGB,
                 docker = msgf_docker,
                 disks = msgf_disk,
-                preemptible = msgf_preemptible,
+                preemptible = num_preemptible_attempts,
                 input_mzml = msconvert.mzml,
                 fasta_sequence_db = fasta_sequence_db,
                 sequencedb_files = msgf_sequences.sequencedb_files,
@@ -187,7 +184,7 @@ workflow proteomics_msgfplus {
                 ramGB = msconvert_ramGB,
                 docker = msconvert_docker,
                 disks = msconvert_disk,
-                preemptible = msconvert_preemptible,
+                preemptible = num_preemptible_attempts,
                 input_mzml = msconvert.mzml,
                 input_mzid = msgf_tryptic.mzid
         }
@@ -198,7 +195,7 @@ workflow proteomics_msgfplus {
                 ramGB = msconvert_ramGB,
                 docker = ppm_errorcharter_docker,
                 disks = msconvert_disk,
-                preemptible = msconvert_preemptible,
+                preemptible = num_preemptible_attempts,
                 input_fixed_mzml = msconvert_mzrefiner.mzml_fixed,
                 input_mzid = msgf_tryptic.mzid
         }
@@ -209,7 +206,7 @@ workflow proteomics_msgfplus {
                 ramGB = msgf_ramGB,
                 docker = msgf_docker,
                 disks = msgf_disk,
-                preemptible = msgf_preemptible,
+                preemptible = num_preemptible_attempts,
                 input_fixed_mzml = msconvert_mzrefiner.mzml_fixed,
                 fasta_sequence_db = fasta_sequence_db,
                 sequencedb_files = msgf_sequences.sequencedb_files,
@@ -222,7 +219,7 @@ workflow proteomics_msgfplus {
                 ramGB = msconvert_ramGB,
                 docker = mzidtotsvconverter_docker,
                 disks = msconvert_disk,
-                preemptible = msconvert_preemptible,
+                preemptible = num_preemptible_attempts,
                 input_mzid_final = msgf_identification.mzid_final
         }
 
@@ -232,7 +229,7 @@ workflow proteomics_msgfplus {
                 ramGB = phrp_ramGB,
                 docker = phrp_docker,
                 disks = phrp_disk,
-                preemptible = phrp_preemptible,
+                preemptible = num_preemptible_attempts,
                 input_tsv = mzidtotsvconverter.tsv,
                 phrp_parameter_m = phrp_parameter_m,
                 phrp_parameter_t = phrp_parameter_t,
@@ -249,7 +246,7 @@ workflow proteomics_msgfplus {
                     ramGB = select_first([ascore_ramGB]),
                     docker = select_first([ascore_docker]),
                     disks = ascore_disk,
-                    preemptible = select_first([ascore_preemptible]),
+                    preemptible = num_preemptible_attempts,
                     input_syn = phrp.syn,
                     input_fixed_mzml = msgf_identification.rename_mzmlfixed,
                     ascore_parameter_p = select_first([ascore_parameter_p]),
@@ -266,7 +263,7 @@ workflow proteomics_msgfplus {
                 ramGB = select_first([wrapper_ramGB]),
                 docker = select_first([wrapper_docker]),
                 disks = wrapper_disk,
-                preemptible = select_first([wrapper_preemptible]),
+                preemptible = num_preemptible_attempts,
                 fractions = select_first([sd_fractions]),
                 references = select_first([sd_references]),
                 samples = select_first([sd_samples]),


### PR DESCRIPTION
There isn't really any need to specify different numbers of pre-emptible attempts per job, since outputs should be cached irrespective of pre-emptible attributes