### PR TITLE
Standardize preemptible VM attempts handling across proteomics pipelines

### DIFF
--- a/inputs/templates/maxquant/config-maxquant.json
+++ b/inputs/templates/maxquant/config-maxquant.json
@@ -5,6 +5,7 @@
   "proteomics_maxquant.mq_disk": 500,
   "proteomics_maxquant.mq_docker": "docker-repository/maxquant:v1660",
   "proteomics_maxquant.mq_parameters": "gcp-parameters",
-  "proteomics_maxquant.mq_ramGB": 380
+  "proteomics_maxquant.mq_ramGB": 380,
+  "proteomics_maxquant.num_preemptible_attempts": 2
 }
 

--- a/inputs/templates/msgfplus/config-msgfplus-ac-lf.json
+++ b/inputs/templates/msgfplus/config-msgfplus-ac-lf.json
@@ -44,10 +44,5 @@
   "proteomics_msgfplus.wrapper_docker": "docker-repository/plexedpiper:v0.4.1",
   "proteomics_msgfplus.wrapper_ncpu": 8,
   "proteomics_msgfplus.wrapper_ramGB": 60,
-  "proteomics_msgfplus.masic_preemptible": 2,
-  "proteomics_msgfplus.msconvert_preemptible": 2,
-  "proteomics_msgfplus.msgf_preemptible": 2,
-  "proteomics_msgfplus.phrp_preemptible": 2,
-  "proteomics_msgfplus.ascore_preemptible": 2,
-  "proteomics_msgfplus.wrapper_preemptible": 2
+  "proteomics_msgfplus.num_preemptible_attempts": 2
 }

--- a/inputs/templates/msgfplus/config-msgfplus-ac-tmt11.json
+++ b/inputs/templates/msgfplus/config-msgfplus-ac-tmt11.json
@@ -47,10 +47,5 @@
   "proteomics_msgfplus.refine_prior": true,
   "proteomics_msgfplus.sequence_db_name": "String",
   "proteomics_msgfplus.unique_only": false,
-  "proteomics_msgfplus.masic_preemptible": 2,
-  "proteomics_msgfplus.msconvert_preemptible": 2,
-  "proteomics_msgfplus.msgf_preemptible": 2,
-  "proteomics_msgfplus.phrp_preemptible": 2,
-  "proteomics_msgfplus.ascore_preemptible": 2,
-  "proteomics_msgfplus.wrapper_preemptible": 2
+  "proteomics_msgfplus.num_preemptible_attempts": 2
 }

--- a/inputs/templates/msgfplus/config-msgfplus-ac-tmt16.json
+++ b/inputs/templates/msgfplus/config-msgfplus-ac-tmt16.json
@@ -47,10 +47,5 @@
   "proteomics_msgfplus.refine_prior": true,
   "proteomics_msgfplus.sequence_db_name": "String",
   "proteomics_msgfplus.unique_only": false,
-  "proteomics_msgfplus.masic_preemptible": 2,
-  "proteomics_msgfplus.msconvert_preemptible": 2,
-  "proteomics_msgfplus.msgf_preemptible": 2,
-  "proteomics_msgfplus.phrp_preemptible": 2,
-  "proteomics_msgfplus.ascore_preemptible": 2,
-  "proteomics_msgfplus.wrapper_preemptible": 2
+  "proteomics_msgfplus.num_preemptible_attempts": 2
 }

--- a/inputs/templates/msgfplus/config-msgfplus-ac-tmt18.json
+++ b/inputs/templates/msgfplus/config-msgfplus-ac-tmt18.json
@@ -47,10 +47,5 @@
   "proteomics_msgfplus.refine_prior": true,
   "proteomics_msgfplus.sequence_db_name": "String",
   "proteomics_msgfplus.unique_only": false,
-  "proteomics_msgfplus.masic_preemptible": 2,
-  "proteomics_msgfplus.msconvert_preemptible": 2,
-  "proteomics_msgfplus.msgf_preemptible": 2,
-  "proteomics_msgfplus.phrp_preemptible": 2,
-  "proteomics_msgfplus.ascore_preemptible": 2,
-  "proteomics_msgfplus.wrapper_preemptible": 2
+  "proteomics_msgfplus.num_preemptible_attempts": 2
 }

--- a/inputs/templates/msgfplus/config-msgfplus-ph-lf.json
+++ b/inputs/templates/msgfplus/config-msgfplus-ph-lf.json
@@ -44,10 +44,5 @@
   "proteomics_msgfplus.wrapper_docker": "docker-repository/plexedpiper:v0.4.1",
   "proteomics_msgfplus.wrapper_ncpu": 8,
   "proteomics_msgfplus.wrapper_ramGB": 60,
-  "proteomics_msgfplus.masic_preemptible": 2,
-  "proteomics_msgfplus.msconvert_preemptible": 2,
-  "proteomics_msgfplus.msgf_preemptible": 2,
-  "proteomics_msgfplus.phrp_preemptible": 2,
-  "proteomics_msgfplus.ascore_preemptible": 2,
-  "proteomics_msgfplus.wrapper_preemptible": 2
+  "proteomics_msgfplus.num_preemptible_attempts": 2
 }

--- a/inputs/templates/msgfplus/config-msgfplus-ph-tmt11.json
+++ b/inputs/templates/msgfplus/config-msgfplus-ph-tmt11.json
@@ -47,10 +47,5 @@
   "proteomics_msgfplus.refine_prior": true,
   "proteomics_msgfplus.sequence_db_name": "String",
   "proteomics_msgfplus.unique_only": false,
-  "proteomics_msgfplus.masic_preemptible": 2,
-  "proteomics_msgfplus.msconvert_preemptible": 2,
-  "proteomics_msgfplus.msgf_preemptible": 2,
-  "proteomics_msgfplus.phrp_preemptible": 2,
-  "proteomics_msgfplus.ascore_preemptible": 2,
-  "proteomics_msgfplus.wrapper_preemptible": 2
+  "proteomics_msgfplus.num_preemptible_attempts": 2
 }

--- a/inputs/templates/msgfplus/config-msgfplus-ph-tmt16.json
+++ b/inputs/templates/msgfplus/config-msgfplus-ph-tmt16.json
@@ -47,10 +47,5 @@
   "proteomics_msgfplus.refine_prior": true,
   "proteomics_msgfplus.sequence_db_name": "String",
   "proteomics_msgfplus.unique_only": false,
-  "proteomics_msgfplus.masic_preemptible": 2,
-  "proteomics_msgfplus.msconvert_preemptible": 2,
-  "proteomics_msgfplus.msgf_preemptible": 2,
-  "proteomics_msgfplus.phrp_preemptible": 2,
-  "proteomics_msgfplus.ascore_preemptible": 2,
-  "proteomics_msgfplus.wrapper_preemptible": 2
+  "proteomics_msgfplus.num_preemptible_attempts": 2
 }

--- a/inputs/templates/msgfplus/config-msgfplus-ph-tmt18.json
+++ b/inputs/templates/msgfplus/config-msgfplus-ph-tmt18.json
@@ -47,10 +47,5 @@
   "proteomics_msgfplus.refine_prior": true,
   "proteomics_msgfplus.sequence_db_name": "String",
   "proteomics_msgfplus.unique_only": false,
-  "proteomics_msgfplus.masic_preemptible": 2,
-  "proteomics_msgfplus.msconvert_preemptible": 2,
-  "proteomics_msgfplus.msgf_preemptible": 2,
-  "proteomics_msgfplus.phrp_preemptible": 2,
-  "proteomics_msgfplus.ascore_preemptible": 2,
-  "proteomics_msgfplus.wrapper_preemptible": 2
+  "proteomics_msgfplus.num_preemptible_attempts": 2
 }

--- a/inputs/templates/msgfplus/config-msgfplus-pr-lf.json
+++ b/inputs/templates/msgfplus/config-msgfplus-pr-lf.json
@@ -36,10 +36,5 @@
   "proteomics_msgfplus.wrapper_docker": "docker-repository/plexedpiper:v0.4.1",
   "proteomics_msgfplus.wrapper_ncpu": 8,
   "proteomics_msgfplus.wrapper_ramGB": 60,
-  "proteomics_msgfplus.masic_preemptible": 2,
-  "proteomics_msgfplus.msconvert_preemptible": 2,
-  "proteomics_msgfplus.msgf_preemptible": 2,
-  "proteomics_msgfplus.phrp_preemptible": 2,
-  "proteomics_msgfplus.ascore_preemptible": 2,
-  "proteomics_msgfplus.wrapper_preemptible": 2
+  "proteomics_msgfplus.num_preemptible_attempts": 2
 }

--- a/inputs/templates/msgfplus/config-msgfplus-pr-tmt11.json
+++ b/inputs/templates/msgfplus/config-msgfplus-pr-tmt11.json
@@ -41,10 +41,5 @@
   "proteomics_msgfplus.refine_prior": true,
   "proteomics_msgfplus.sequence_db_name": "String",
   "proteomics_msgfplus.unique_only": false,
-  "proteomics_msgfplus.masic_preemptible": 2,
-  "proteomics_msgfplus.msconvert_preemptible": 2,
-  "proteomics_msgfplus.msgf_preemptible": 2,
-  "proteomics_msgfplus.phrp_preemptible": 2,
-  "proteomics_msgfplus.ascore_preemptible": 2,
-  "proteomics_msgfplus.wrapper_preemptible": 2
+  "proteomics_msgfplus.num_preemptible_attempts": 2
 }

--- a/inputs/templates/msgfplus/config-msgfplus-pr-tmt16.json
+++ b/inputs/templates/msgfplus/config-msgfplus-pr-tmt16.json
@@ -41,10 +41,5 @@
   "proteomics_msgfplus.refine_prior": true,
   "proteomics_msgfplus.sequence_db_name": "String",
   "proteomics_msgfplus.unique_only": false,
-  "proteomics_msgfplus.masic_preemptible": 2,
-  "proteomics_msgfplus.msconvert_preemptible": 2,
-  "proteomics_msgfplus.msgf_preemptible": 2,
-  "proteomics_msgfplus.phrp_preemptible": 2,
-  "proteomics_msgfplus.ascore_preemptible": 2,
-  "proteomics_msgfplus.wrapper_preemptible": 2
+  "proteomics_msgfplus.num_preemptible_attempts": 2
 }

--- a/inputs/templates/msgfplus/config-msgfplus-pr-tmt18.json
+++ b/inputs/templates/msgfplus/config-msgfplus-pr-tmt18.json
@@ -41,10 +41,5 @@
   "proteomics_msgfplus.refine_prior": true,
   "proteomics_msgfplus.sequence_db_name": "String",
   "proteomics_msgfplus.unique_only": false,
-  "proteomics_msgfplus.masic_preemptible": 2,
-  "proteomics_msgfplus.msconvert_preemptible": 2,
-  "proteomics_msgfplus.msgf_preemptible": 2,
-  "proteomics_msgfplus.phrp_preemptible": 2,
-  "proteomics_msgfplus.ascore_preemptible": 2,
-  "proteomics_msgfplus.wrapper_preemptible": 2
+  "proteomics_msgfplus.num_preemptible_attempts": 2
 }

--- a/inputs/templates/msgfplus/config-msgfplus-ub-lf.json
+++ b/inputs/templates/msgfplus/config-msgfplus-ub-lf.json
@@ -44,10 +44,5 @@
   "proteomics_msgfplus.wrapper_docker": "docker-repository/plexedpiper:v0.4.1",
   "proteomics_msgfplus.wrapper_ncpu": 8,
   "proteomics_msgfplus.wrapper_ramGB": 60,
-  "proteomics_msgfplus.masic_preemptible": 2,
-  "proteomics_msgfplus.msconvert_preemptible": 2,
-  "proteomics_msgfplus.msgf_preemptible": 2,
-  "proteomics_msgfplus.phrp_preemptible": 2,
-  "proteomics_msgfplus.ascore_preemptible": 2,
-  "proteomics_msgfplus.wrapper_preemptible": 2
+  "proteomics_msgfplus.num_preemptible_attempts": 2
 }

--- a/inputs/templates/msgfplus/config-msgfplus-ub-tmt11.json
+++ b/inputs/templates/msgfplus/config-msgfplus-ub-tmt11.json
@@ -47,10 +47,5 @@
   "proteomics_msgfplus.refine_prior": true,
   "proteomics_msgfplus.sequence_db_name": "String",
   "proteomics_msgfplus.unique_only": false,
-  "proteomics_msgfplus.masic_preemptible": 2,
-  "proteomics_msgfplus.msconvert_preemptible": 2,
-  "proteomics_msgfplus.msgf_preemptible": 2,
-  "proteomics_msgfplus.phrp_preemptible": 2,
-  "proteomics_msgfplus.ascore_preemptible": 2,
-  "proteomics_msgfplus.wrapper_preemptible": 2
+  "proteomics_msgfplus.num_preemptible_attempts": 2
 }

--- a/inputs/templates/msgfplus/config-msgfplus-ub-tmt16.json
+++ b/inputs/templates/msgfplus/config-msgfplus-ub-tmt16.json
@@ -47,10 +47,5 @@
   "proteomics_msgfplus.refine_prior": true,
   "proteomics_msgfplus.sequence_db_name": "String",
   "proteomics_msgfplus.unique_only": false,
-  "proteomics_msgfplus.masic_preemptible": 2,
-  "proteomics_msgfplus.msconvert_preemptible": 2,
-  "proteomics_msgfplus.msgf_preemptible": 2,
-  "proteomics_msgfplus.phrp_preemptible": 2,
-  "proteomics_msgfplus.ascore_preemptible": 2,
-  "proteomics_msgfplus.wrapper_preemptible": 2
+  "proteomics_msgfplus.num_preemptible_attempts": 2
 }

--- a/inputs/templates/msgfplus/config-msgfplus-ub-tmt18.json
+++ b/inputs/templates/msgfplus/config-msgfplus-ub-tmt18.json
@@ -47,10 +47,5 @@
   "proteomics_msgfplus.refine_prior": true,
   "proteomics_msgfplus.sequence_db_name": "String",
   "proteomics_msgfplus.unique_only": false,
-  "proteomics_msgfplus.masic_preemptible": 2,
-  "proteomics_msgfplus.msconvert_preemptible": 2,
-  "proteomics_msgfplus.msgf_preemptible": 2,
-  "proteomics_msgfplus.phrp_preemptible": 2,
-  "proteomics_msgfplus.ascore_preemptible": 2,
-  "proteomics_msgfplus.wrapper_preemptible": 2
+  "proteomics_msgfplus.num_preemptible_attempts": 2
 }

--- a/scripts/copy_pipeline_results.py
+++ b/scripts/copy_pipeline_results.py
@@ -634,7 +634,7 @@ def main():
         logger.info("This is a dry run, no files will be copied")
 
     # Validate and (optionally) copy vial metadata file before any other operation
-    if hasattr(args, "vial_metadata_path") and args.vial_metadata_path:
+    if args.vial_metadata_path:
         try:
             src_bucket_name, src_blob_path = parse_bucket_path(args.vial_metadata_path)
             client = Client(project=args.project)

--- a/scripts/copy_pipeline_results.py
+++ b/scripts/copy_pipeline_results.py
@@ -606,6 +606,13 @@ def create_args():
         action="store_true",
         help="Don't actually copy the files, just print what it's going to do",
     )
+    parser.add_argument(
+        "-v",
+        "--vial_metadata_path",
+        required=False,
+        type=str,
+        help="Full GCS path to vial metadata file (e.g. gs://bucket-name/full/path/file_name_vial_manifest.txt)",
+    )
     return parser
 
 
@@ -625,6 +632,33 @@ def main():
 
     if args.dry_run:
         logger.info("This is a dry run, no files will be copied")
+
+    # Validate and (optionally) copy vial metadata file before any other operation
+    if hasattr(args, "vial_metadata_path") and args.vial_metadata_path:
+        try:
+            src_bucket_name, src_blob_path = parse_bucket_path(args.vial_metadata_path)
+            client = Client(project=args.project)
+            src_bucket = client.get_bucket(src_bucket_name)
+            src_blob = src_bucket.get_blob(src_blob_path)
+            if src_blob is None:
+                logger.warning("Vial metadata file does not exist: %s", args.vial_metadata_path)
+            else:
+                logger.info("Vial metadata file found: %s", args.vial_metadata_path)
+                # Prepare destination path
+                dest_bucket_name, dest_prefix = parse_bucket_path(args.destination)
+                dest_bucket = client.get_bucket(dest_bucket_name)
+                dest_file_name = Path(src_blob_path).name
+                dest_blob_path = f"{dest_prefix.rstrip('/')}/{dest_file_name}" if dest_prefix else dest_file_name
+                if args.dry_run:
+                    logger.info(
+                        "DRY RUN: Would copy vial metadata to gs://%s/%s", dest_bucket_name, dest_blob_path
+                    )
+                else:
+                    # Perform copy
+                    src_bucket.copy_blob(src_blob, dest_bucket, new_name=dest_blob_path)
+                    logger.info("Copied vial metadata to gs://%s/%s", dest_bucket_name, dest_blob_path)
+        except Exception as e:
+            logger.warning("Could not validate or copy vial metadata file: %s", e)
 
     if method_proteomics == "maxquant":
         logger.info("PROTEOMICS METHOD: maxquant")

--- a/scripts/copy_pipeline_results.py
+++ b/scripts/copy_pipeline_results.py
@@ -658,7 +658,7 @@ def main():
                     # Perform copy
                     src_bucket.copy_blob(src_blob, dest_bucket, new_name=dest_blob_path)
                     logger.info("Copied vial metadata to gs://%s/%s", dest_bucket_name, dest_blob_path)
-        except Exception as e:
+        except (GoogleAPICallError, ValueError) as e:
             logger.warning("Could not validate or copy vial metadata file: %s", e)
 
     if method_proteomics == "maxquant":

--- a/scripts/copy_pipeline_results.py
+++ b/scripts/copy_pipeline_results.py
@@ -641,7 +641,8 @@ def main():
             src_bucket = client.get_bucket(src_bucket_name)
             src_blob = src_bucket.get_blob(src_blob_path)
             if src_blob is None:
-                logger.warning("Vial metadata file does not exist: %s", args.vial_metadata_path)
+                logger.error("Vial metadata file does not exist: %s. Exiting.", args.vial_metadata_path)
+                sys.exit(1)
             else:
                 logger.info("Vial metadata file found: %s", args.vial_metadata_path)
                 # Prepare destination path

--- a/scripts/create_study_design.py
+++ b/scripts/create_study_design.py
@@ -11,22 +11,38 @@ import pandas as pd
 from google.cloud import storage
 from io import StringIO
 import warnings
+import http.client
+
+# Disable low-level HTTP debug logs
+http.client.HTTPConnection.debuglevel = 0
 
 # Silence Google's warnings and logs
-logging.getLogger("google.auth").setLevel(logging.ERROR)
-logging.getLogger("google.auth.transport").setLevel(logging.ERROR)
-logging.getLogger("google.cloud").setLevel(logging.ERROR)
-logging.getLogger("google.api_core").setLevel(logging.ERROR)
-logging.getLogger("googleapiclient.discovery_cache").setLevel(logging.ERROR)
-logging.getLogger("urllib3").setLevel(logging.WARNING)
-logging.getLogger("urllib3.connectionpool").setLevel(logging.WARNING)
-
-# Suppress UserWarnings from google.auth
-warnings.filterwarnings("ignore", category=UserWarning, module="google.auth")
-
-# === Logging Setup === #
+# Set up your script-level logger
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(message)s")
+logger.setLevel(logging.INFO)
+
+# Basic config (don't use DEBUG level here unless needed)
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(message)s"
+)
+
+# Silence noisy loggers
+for lib in [
+    "google.auth",
+    "google.auth.transport",
+    "google.auth.transport.requests",
+    "google.api_core",
+    "google.cloud",
+    "google.cloud.storage",
+    "google.resumable_media",
+    "urllib3",
+    "urllib3.connectionpool",
+]:
+    logging.getLogger(lib).setLevel(logging.WARNING)
+
+# Suppress specific UserWarnings
+warnings.filterwarnings("ignore", category=UserWarning, module="google.auth")
 
 # === GCS Support === #
 def is_gcs_path(input_results_folder: str) -> bool:
@@ -773,12 +789,9 @@ def main():
 
     if has_ref:
         samples["MeasurementName"] = samples["ReporterAlias"]
-        ref_mask = samples["ReporterAlias"].str.contains(
-            r"^ref",
-            case=False,
-            regex=True,
-        )
-        samples.loc[ref_mask, "MeasurementName"] = None
+        # Matches values in the "ReporterAlias" column that start with "Ref" or "ref" (case-insensitive)
+        ref_mask = samples["ReporterAlias"].str.contains(r"^ref", case=False, regex=True)
+        samples.loc[ref_mask, "MeasurementName"] = "NA"
 
     # Select only required columns
     samples = samples[

--- a/scripts/create_study_design.py
+++ b/scripts/create_study_design.py
@@ -410,9 +410,9 @@ def process_folder(raw_folder: str, is_gcs: bool = False, bucket_name: str = Non
             # Validate filenames
             invalid_files = [
                 blob.name for blob in non_empty_raw_files
-                if not re.search(r"_f\d{2,3}\.raw$", os.path.basename(blob.name))
+                if not re.search(r"_f(r)?\d{2,3}\.raw$", os.path.basename(blob.name))
             ]
-            
+
             if invalid_files:
                     msg = f"The following raw files do not follow the format of proposed file name: {'\n'.join(invalid_files)}. \n\nPlease check the MoTrPAC control vocabulary guidelines.\n"
                     raise ValueError(msg)
@@ -420,7 +420,7 @@ def process_folder(raw_folder: str, is_gcs: bool = False, bucket_name: str = Non
             # Extract fraction numbers
             fraction_nums = []
             for blob in non_empty_raw_files:
-                match = re.search(r"_f(\d{2,3})\.raw$", os.path.basename(blob.name))
+                match = re.search(r"_f(?:r)?(\d{2,3})\.raw$", os.path.basename(blob.name))
                 if match:
                     fraction_nums.append(int(match.group(1)))
 
@@ -433,8 +433,11 @@ def process_folder(raw_folder: str, is_gcs: bool = False, bucket_name: str = Non
 
                 if missing_fracs:
                     all_basenames = {os.path.basename(b.name) for b in non_empty_raw_files}
+                    sample_prefix = os.path.splitext(os.path.basename(non_empty_raw_files[0].name))[0].rsplit("_f", 1)[0]
+                    has_fr = "_fr" in os.path.basename(non_empty_raw_files[0].name)
+                    suffix = "fr" if has_fr else "f"
                     expected_names = {
-                        f"{os.path.splitext(os.path.basename(b.name))[0].split('_f')[0]}_f{str(i).zfill(2)}.raw"
+                        f"{sample_prefix}_{suffix}{str(i).zfill(2)}.raw"
                         for i in range(min_frac, max_frac + 1)
                     }
                     missing_names = sorted(expected_names - all_basenames)
@@ -497,9 +500,8 @@ def process_folder(raw_folder: str, is_gcs: bool = False, bucket_name: str = Non
 
             if raw_files:
                 invalid_files = [
-                    f
-                    for f in raw_files
-                    if not re.search(r"_f\d{2,3}\.raw$", os.path.basename(f))
+                    f for f in raw_files
+                    if not re.search(r"_f(r)?\d{2,3}\.raw$", os.path.basename(f))
                 ]
                 if invalid_files:
                     msg = f"The following raw files do not follow the format of proposed file name: {'\n'.join(invalid_files)}. \n\nPlease check the MoTrPAC control vocabulary guidelines.\n"
@@ -508,7 +510,7 @@ def process_folder(raw_folder: str, is_gcs: bool = False, bucket_name: str = Non
                 # Extract fraction numbers from filenames
                 fraction_nums = []
                 for f in raw_files:
-                    match = re.search(r"_f(\d{2,3})\.raw$", os.path.basename(f))
+                    match = re.search(r"_f(?:r)?(\d{2,3})\.raw$", os.path.basename(f))
                     if match:
                         fraction_nums.append(int(match.group(1)))
 
@@ -521,14 +523,17 @@ def process_folder(raw_folder: str, is_gcs: bool = False, bucket_name: str = Non
 
                     if missing_fracs:
                         all_basenames = {os.path.basename(f) for f in raw_files}
+                        sample_prefix = os.path.splitext(os.path.basename(raw_files[0]))[0].rsplit("_f", 1)[0]
+                        has_fr = "_fr" in os.path.basename(raw_files[0])
+                        suffix = "fr" if has_fr else "f"
                         expected_names = {
-                            f"{os.path.splitext(os.path.basename(f))[0].split('_f')[0]}_f{str(i).zfill(2)}.raw"
+                            f"{sample_prefix}_{suffix}{str(i).zfill(2)}.raw"
                             for i in range(min_frac, max_frac + 1)
                         }
                         missing_names = sorted(expected_names - all_basenames)
 
                         logger.warning(
-                            "🚨 Warning: Missing fraction files in %s. Expected fractions from f%s to f%s."
+                            "🚨 Warning: Missing fraction files in %s. Expected fractions from f%s to f%s.\n"
                             "Missing files:\n %s \nContinuing with available files.\n",
                             subfolder,
                             str(min_frac).zfill(2),

--- a/scripts/create_study_design.py
+++ b/scripts/create_study_design.py
@@ -369,7 +369,7 @@ def process_manifest(raw_folder: str, is_gcs: bool = False, bucket_name: str = N
             else:
                 fractions = pd.concat([fractions, manifest], ignore_index=True)
             
-    if not fractions:
+    if fractions is None or fractions.empty:
         raise ValueError("No manifest files found in the provided folder.")
 
     return fractions

--- a/scripts/create_study_design.py
+++ b/scripts/create_study_design.py
@@ -6,14 +6,62 @@ import logging
 import os
 import re
 from datetime import datetime
-
 import numpy as np
 import pandas as pd
+from google.cloud import storage
+from io import StringIO
+import warnings
 
+# Silence Google's warnings and logs
+logging.getLogger("google.auth").setLevel(logging.ERROR)
+logging.getLogger("google.auth.transport").setLevel(logging.ERROR)
+logging.getLogger("google.cloud").setLevel(logging.ERROR)
+logging.getLogger("google.api_core").setLevel(logging.ERROR)
+logging.getLogger("googleapiclient.discovery_cache").setLevel(logging.ERROR)
+logging.getLogger("urllib3").setLevel(logging.WARNING)
+logging.getLogger("urllib3.connectionpool").setLevel(logging.WARNING)
+
+# Suppress UserWarnings from google.auth
+warnings.filterwarnings("ignore", category=UserWarning, module="google.auth")
+
+# === Logging Setup === #
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(message)s")
 
+# === GCS Support === #
+def is_gcs_path(input_results_folder: str) -> bool:
+    """Check if provided path is a GCS path."""
+    return input_results_folder.startswith("gs://")
 
+def parse_gcs_path(gcs_path: str) -> tuple[str, str]:
+    """Parse gs://bucket_name/path/to/folder into bucket_name and blob prefix."""
+    if not is_gcs_path(gcs_path):
+        raise ValueError("Not a valid GCS path with prefix 'gs://'")
+    
+    path = gcs_path.replace("gs://", "")
+    parts = path.split("/", 1)
+    bucket_name = parts[0]
+    blob_path = parts[1] if len(parts) > 1 else ""
+
+    return bucket_name, blob_path.rstrip("/")
+
+def list_gcs_files(bucket_name: str, prefix: str, suffix: str = "") -> list[str]:
+    gcs_client = storage.Client()
+    bucket = gcs_client.bucket(bucket_name)
+    return [
+        blob.name
+        for blob in bucket.list_blobs(prefix=prefix)
+        if blob.name.endswith(suffix)
+    ]
+
+def read_gcs_tsv(bucket_name: str, blob_name: str, sep="\t") -> pd.DataFrame:
+    gcs_client = storage.Client()
+    bucket = gcs_client.bucket(bucket_name)
+    blob = bucket.blob(blob_name)
+    content = blob.download_as_text()
+    return pd.read_csv(StringIO(content), sep=sep)
+
+# === Validation Functions === #
 def validate_batch(input_results_folder: str) -> str:
     """Extract BATCH_YYYYMMDD folder from input folder path.
 
@@ -36,9 +84,7 @@ def validate_batch(input_results_folder: str) -> str:
     return batch_match.group(1)
 
 
-def validate_phase(
-    input_results_folder: str, *, return_phase: bool = True
-) -> str | None:
+def validate_phase(input_results_folder: str, *, return_phase: bool = True) -> str | None:
     """Extract PHASE from input folder path.
 
     :param input_results_folder: input_results_folder path
@@ -91,72 +137,15 @@ def validate_tissue(input_results_folder: str) -> str:
     :raises: ValueError: If tissue code is not valid
     """
     # Define the list of valid tissue codes as in bic_animal_tissue_code$bic_tissue_code
-    bic_tissue_codes = [
-        "T01",
-        "T02",
-        "T03",
-        "T04",
-        "T05",
-        "T06",
-        "T07",
-        "T08",
-        "T09",
-        "T10",
-        "T11",
-        "T12",
-        "T13",
-        "T14",
-        "T15",
-        "T16",
-        "T17",
-        "T18",
-        "T19",
-        "T20",
-        "T21",
-        "T30",
-        "T31",
-        "T32",
-        "T33",
-        "T34",
-        "T35",
-        "T36",
-        "T37",
-        "T38",
-        "T39",
-        "T40",
-        "T41",
-        "T42",
-        "T43",
-        "T44",
-        "T45",
-        "T46",
-        "T47",
-        "T48",
-        "T49",
-        "T50",
-        "T51",
-        "T52",
-        "T53",
-        "T54",
-        "T55",
-        "T56",
-        "T57",
-        "T58",
-        "T59",
-        "T60",
-        "T61",
-        "T62",
-        "T63",
-        "T64",
-        "T65",
-        "T66",
-        "T67",
-        "T68",
-        "T69",
-        "T70",
-        "T77",
-        "T99",
-    ]
+    bic_tissue_codes = ["T01", "T02", "T03", "T04", "T05", "T06", "T07", "T08", "T09", 
+                        "T10", "T11", "T12", "T13", "T14", "T15", "T16", "T17", "T18", "T19", 
+                        "T20", "T21",
+                        "T30", "T31", "T32",  "T33", "T34", "T35", "T36", "T37", "T38", "T39",
+                        "T40", "T41", "T42", "T43", "T44", "T45", "T46", "T47", "T48", "T49",
+                        "T50", "T51", "T52", "T53", "T54", "T55", "T56", "T57", "T58", "T59",
+                        "T60", "T61", "T62", "T63", "T64", "T65", "T66", "T67", "T68", "T69",
+                        "T70", "T77",
+                        "T99"]
 
     # Extract tissue code using regex similar to gsub in R
     match = re.search(r"(.*)(T[0-9]{2,3})(.*)", input_results_folder)
@@ -206,13 +195,7 @@ def find_unique_tmt_channel(tempcol: list[str] | np.ndarray | pd.Series) -> str:
     raise ValueError(msg)
 
 
-def check_tmt_channels(
-    tmt_type: str,
-    tmt_expected: list[str],
-    temp: pd.DataFrame,
-    tmt_col: str,
-    tmt_details: str,
-) -> None:
+def check_tmt_channels(tmt_type: str, tmt_expected: list[str], temp: pd.DataFrame, tmt_col: str, tmt_details: str) -> None:
     """Check TMT channel consistency and provide detailed comparison.
 
     :param tmt_type: Type of TMT experiment
@@ -265,12 +248,10 @@ def fix_duplicates(meta: pd.DataFrame) -> pd.DataFrame:
         meta["vial_label"] = unique_names
     return meta
 
-
+# === CLI Argument Parsing === #
 def cli_args() -> argparse.Namespace:
     """Set up command line argument parser."""
-    parser = argparse.ArgumentParser(
-        description="Generate PlexedPiper study_design files",
-    )
+    parser = argparse.ArgumentParser(description="Generate PlexedPiper study_design files")
     parser.add_argument(
         "-f",
         "--file_vial_metadata",
@@ -301,102 +282,145 @@ def cli_args() -> argparse.Namespace:
         help="One of the following options: tmt11, tmt16, tmt18",
     )
     parser.add_argument("-p", "--phase", type=str, required=True, help="MOTRPAC PHASE")
-    # Parse arguments
-    return parser.parse_args()
-
-
-def process_manifest(raw_folder: str) -> pd.DataFrame:
-    """Get fractions from file manifest files."""
-    fractions = None
-    logger.info("(from processing manifest files):")
-    file_manifest = glob.glob(
-        os.path.join(raw_folder, "**/*metadata_file.txt"),
-        recursive=True,
+    
+    parser.add_argument(
+        "-o", "--output_dir", type=str,
+        help="Output directory for study_design files (REQUIRED if --batch_folder is a GCS path)"
     )
-    file_manifest.extend(
-        glob.glob(
-            os.path.join(raw_folder, "**/*raw_metadata_file*"),
-            recursive=True,
-        ),
-    )
-    # Sort the file paths to ensure they are in the correct order
-    file_manifest.sort()
-    for i, manifest_file in enumerate(file_manifest, 1):
-        logger.info("\t%s. File: %s", i, os.path.basename(manifest_file))
 
-        manifest = pd.read_csv(manifest_file, sep="\t")
+    args = parser.parse_args()
 
-        manifest = manifest[["file_name"]]
-        manifest = manifest.rename(columns={"file_name": "Dataset"})
+    # Enforce output_dir if GCS is used
+    if is_gcs_path(args.batch_folder) and not args.output_dir:
+        parser.error("--output_dir is required when --batch_folder is a GCS path")
 
-        manifest["PlexID"] = f"S{i}"
+    return args
 
-        if fractions is None:
-            fractions = manifest
-        else:
-            fractions = pd.concat([fractions, manifest], ignore_index=True)
+# === Main Processing Functions === #
+def process_manifest(raw_folder: str, is_gcs: bool = False, bucket_name: str = None) -> pd.DataFrame:
+    """Get fractions from file manifest files in either local folder or GCS bucket."""
+
+    is_gcs = is_gcs_path(raw_folder)
+    
+    # If the path is a GCS path, parse it
+    if is_gcs:
+        fractions = None
+        logger.info("(from processing manifest files in GCS bucket):")
+        bucket, prefix = parse_gcs_path(raw_folder)
+        # List relevant metadata files in GCS bucket
+        metadata_files = list_gcs_files(bucket, prefix, suffix="metadata_file.txt")
+        metadata_files += list_gcs_files(bucket, prefix, suffix="raw_metadata_file")
+
+        # Sort the GCS blob paths
+        metadata_files.sort()
+
+        for i, blob_name in enumerate(metadata_files, 1):
+            logger.info("\t%s. File: %s", i, os.path.basename(blob_name))
+
+            manifest = read_gcs_tsv(bucket, blob_name, sep="\t")
+            manifest = manifest[["file_name"]].rename(columns={"file_name": "Dataset"})
+            manifest["PlexID"] = f"S{i}"
+            
+            if fractions is None:
+                fractions = manifest
+            else:
+                fractions = pd.concat([fractions, manifest], ignore_index=True)
+
+    else:
+        # If the path is a local folder, process it as before
+        logger.info("(from processing manifest files in local folder):")
+        fractions = None
+
+        # List relevant metadata files in local folder
+        file_manifest = glob.glob(os.path.join(raw_folder, "**/*metadata_file.txt"), recursive=True)
+        file_manifest.extend(glob.glob(os.path.join(raw_folder, "**/*raw_metadata_file*"), recursive=True))
+
+        # Sort the file paths to ensure they are in the correct order
+        file_manifest.sort()
+
+        for i, manifest_file in enumerate(file_manifest, 1):
+            logger.info("\t%s. File: %s", i, os.path.basename(manifest_file))
+
+            manifest = pd.read_csv(manifest_file, sep="\t")
+
+            manifest = manifest[["file_name"]]
+            manifest = manifest.rename(columns={"file_name": "Dataset"})
+
+            manifest["PlexID"] = f"S{i}"
+            
+            if fractions is None:
+                fractions = manifest
+            else:
+                fractions = pd.concat([fractions, manifest], ignore_index=True)
+            
+    if not fractions:
+        raise ValueError("No manifest files found in the provided folder.")
 
     return fractions
 
+def process_folder(raw_folder: str, is_gcs: bool = False, bucket_name: str = None) -> pd.DataFrame:
+    """Get fractions from raw files in either GCS bucket or local folder."""
 
-def process_folder(raw_folder: str) -> pd.DataFrame:
-    """Get fractions from raw files in the folder."""
-    logger.info("(from listing raw files in folder)")
-    # Check subfolders
-    raw_subfolders = [
-        f
-        for f in glob.glob(os.path.join(raw_folder, "**/"))
-        if re.search(r".*/\d{2}.*", f)
-    ]
-    raw_subfolders.sort()
-    if not raw_subfolders:
-        msg = "The number of subfolders with raw data is equal to 0, which might mean that this submission is not according to MoTrPAC guidelines"
-        raise ValueError(msg)
-    fr_list = []
-    for sf, subfolder in enumerate(raw_subfolders, 1):
-        raw_files = glob.glob(os.path.join(subfolder, "**/*.raw"), recursive=True)
+    # If the path is a GCS path, parse it
+    if is_gcs:
+        logger.info("(from listing raw files in GCS bucket)")
+        fr_list = []
+        if not bucket_name:
+            raise ValueError("Bucket name must be provided when using GCS.")
+        prefix = raw_folder
+        gcs_client = storage.Client()
+        bucket = gcs_client.bucket(bucket_name)
 
-        # Check and exclude empty *raw files
-        non_empty_raw_files = []
-        empty_raw_files = []
+        # Collect subdirectories under prefix (match MoTrPAC subfolder format)
+        raw_subfolders = set()
+        for blob in gcs_client.list_blobs(bucket_name, prefix=prefix):
+            match = re.search(r"(.*/\d{2}[^/]*)/.*\.raw$", blob.name)
+            if match:
+                raw_subfolders.add(match.group(1))
+        raw_subfolders = sorted(raw_subfolders)
 
-        for raw_file in raw_files:
-            try:
-                with open(raw_file, "rb") as f:  # binary mode just in case
-                    first_line = f.readline()
-                    if first_line.strip():  # non-empty
-                        non_empty_raw_files.append(raw_file)
-                    else:
-                        empty_raw_files.append(os.path.basename(raw_file))
-            except Exception as err:
-                logger.warning("⚠️ Could not read %s", raw_file, exc_info=err)
-                empty_raw_files.append(os.path.basename(raw_file))
+        if not raw_subfolders:
+            raise ValueError("The number of subfolders with raw data is equal to 0, which might mean that this submission is not according to MoTrPAC guidelinea. Check MoTrPAC submission structure.")
+        
+        for sf, subfolder_prefix in enumerate(raw_subfolders, 1):
+            blobs = list(bucket.list_blobs(prefix=subfolder_prefix))
+            raw_files = [blob for blob in blobs if blob.name.endswith(".raw")]
 
-        if empty_raw_files:
-            logger.warning(
-                "🚨 Warning: The following raw files in %s appears to be empty: %s\n"
-                "Please inspect for issues. Analysis will continue with non-empty files.\n",
-                subfolder,
-                "\n".join(empty_raw_files),
-            )
+            # Filter out empty files
+            non_empty_raw_files = []
+            empty_raw_files = []
 
-        # Use only non-empty files going forward
-        raw_files = non_empty_raw_files
+            for blob in raw_files:
+                if blob.size == 0:
+                    empty_raw_files.append(os.path.basename(blob.name))
+                else:
+                    non_empty_raw_files.append(blob)
 
-        if raw_files:
+            if empty_raw_files:
+                logger.warning(
+                    "🚨 Warning: The following raw files in %s appears to be empty: %s\n"
+                    "Please inspect for issues. Analysis will continue with non-empty files.\n",
+                    subfolder_prefix,
+                    "\n".join(empty_raw_files),
+                )
+
+            if not non_empty_raw_files:
+                raise ValueError(f"No valid .raw files in GCS subfolder: {subfolder_prefix}")
+
+            # Validate filenames
             invalid_files = [
-                f
-                for f in raw_files
-                if not re.search(r"_f\d{2,3}\.raw$", os.path.basename(f))
+                blob.name for blob in non_empty_raw_files
+                if not re.search(r"_f\d{2,3}\.raw$", os.path.basename(blob.name))
             ]
+            
             if invalid_files:
-                msg = f"The following raw files do not follow the format of proposed file name: {'\n'.join(invalid_files)}. \n\nPlease check the MoTrPAC control vocabulary guidelines.\n"
-                raise ValueError(msg)
+                    msg = f"The following raw files do not follow the format of proposed file name: {'\n'.join(invalid_files)}. \n\nPlease check the MoTrPAC control vocabulary guidelines.\n"
+                    raise ValueError(msg)
 
-            # Extract fraction numbers from filenames
+            # Extract fraction numbers
             fraction_nums = []
-            for f in raw_files:
-                match = re.search(r"_f(\d{2,3})\.raw$", os.path.basename(f))
+            for blob in non_empty_raw_files:
+                match = re.search(r"_f(\d{2,3})\.raw$", os.path.basename(blob.name))
                 if match:
                     fraction_nums.append(int(match.group(1)))
 
@@ -408,33 +432,121 @@ def process_folder(raw_folder: str) -> pd.DataFrame:
                 missing_fracs = sorted(expected_fracs - actual_fracs)
 
                 if missing_fracs:
-                    all_basenames = {os.path.basename(f) for f in raw_files}
+                    all_basenames = {os.path.basename(b.name) for b in non_empty_raw_files}
                     expected_names = {
-                        f"{os.path.splitext(os.path.basename(f))[0].split('_f')[0]}_f{str(i).zfill(2)}.raw"
+                        f"{os.path.splitext(os.path.basename(b.name))[0].split('_f')[0]}_f{str(i).zfill(2)}.raw"
                         for i in range(min_frac, max_frac + 1)
                     }
                     missing_names = sorted(expected_names - all_basenames)
 
                     logger.warning(
-                        "🚨 Warning: Missing fraction files in %s. Expected fractions from f%s to f%s."
-                        "Missing files:\n %s \nContinuing with available files.\n",
-                        subfolder,
-                        str(min_frac).zfill(2),
-                        str(max_frac).zfill(2),
-                        "\n ".join(missing_names),
+                        "🚨 Warning: Missing fractions in %s. Expected f%02d to f%02d.\nMissing files:\n%s",
+                        subfolder_prefix, min_frac, max_frac, "\n".join(missing_names)
                     )
+                    
 
-            fr_temp = pd.DataFrame(
-                {"Dataset": [os.path.basename(f) for f in raw_files]},
-            )
+            fr_temp = pd.DataFrame({
+                "Dataset": [os.path.basename(blob.name) for blob in non_empty_raw_files]
+            })
             fr_temp["PlexID"] = f"S{sf}"
             fr_list.append(fr_temp)
+        return pd.concat(fr_list, ignore_index=True)
 
-        else:
-            msg = f"Raw files not found in this folder: {subfolder}"
+    else:
+        logger.info("(from listing raw files in local folder)")
+
+        raw_subfolders = [
+            f
+            for f in glob.glob(os.path.join(raw_folder, "**/"))
+            if re.search(r".*/\d{2}.*", f)
+        ]
+        raw_subfolders.sort()
+        if not raw_subfolders:
+            msg = "The number of subfolders with raw data is equal to 0, which might mean that this submission is not according to MoTrPAC guidelines"
             raise ValueError(msg)
+        fr_list = []
+        for sf, subfolder in enumerate(raw_subfolders, 1):
+            raw_files = glob.glob(os.path.join(subfolder, "**/*.raw"), recursive=True)
 
-    return pd.concat(fr_list, ignore_index=True)
+            # Check and exclude empty *raw files
+            non_empty_raw_files = []
+            empty_raw_files = []
+
+            for raw_file in raw_files:
+                try:
+                    with open(raw_file, "rb") as f:  # binary mode just in case
+                        first_line = f.readline()
+                        if first_line.strip():  # non-empty
+                            non_empty_raw_files.append(raw_file)
+                        else:
+                            empty_raw_files.append(os.path.basename(raw_file))
+                except Exception as err:
+                    logger.warning("⚠️ Could not read %s", raw_file, exc_info=err)
+                    empty_raw_files.append(os.path.basename(raw_file))
+
+            if empty_raw_files:
+                logger.warning(
+                    "🚨 Warning: The following raw files in %s appears to be empty: %s\n"
+                    "Please inspect for issues. Analysis will continue with non-empty files.\n",
+                    subfolder,
+                    "\n".join(empty_raw_files),
+                )
+
+            # Use only non-empty files going forward
+            raw_files = non_empty_raw_files
+
+            if raw_files:
+                invalid_files = [
+                    f
+                    for f in raw_files
+                    if not re.search(r"_f\d{2,3}\.raw$", os.path.basename(f))
+                ]
+                if invalid_files:
+                    msg = f"The following raw files do not follow the format of proposed file name: {'\n'.join(invalid_files)}. \n\nPlease check the MoTrPAC control vocabulary guidelines.\n"
+                    raise ValueError(msg)
+
+                # Extract fraction numbers from filenames
+                fraction_nums = []
+                for f in raw_files:
+                    match = re.search(r"_f(\d{2,3})\.raw$", os.path.basename(f))
+                    if match:
+                        fraction_nums.append(int(match.group(1)))
+
+                if fraction_nums:
+                    min_frac = min(fraction_nums)
+                    max_frac = max(fraction_nums)
+                    expected_fracs = set(range(min_frac, max_frac + 1))
+                    actual_fracs = set(fraction_nums)
+                    missing_fracs = sorted(expected_fracs - actual_fracs)
+
+                    if missing_fracs:
+                        all_basenames = {os.path.basename(f) for f in raw_files}
+                        expected_names = {
+                            f"{os.path.splitext(os.path.basename(f))[0].split('_f')[0]}_f{str(i).zfill(2)}.raw"
+                            for i in range(min_frac, max_frac + 1)
+                        }
+                        missing_names = sorted(expected_names - all_basenames)
+
+                        logger.warning(
+                            "🚨 Warning: Missing fraction files in %s. Expected fractions from f%s to f%s."
+                            "Missing files:\n %s \nContinuing with available files.\n",
+                            subfolder,
+                            str(min_frac).zfill(2),
+                            str(max_frac).zfill(2),
+                            "\n ".join(missing_names),
+                        )
+
+                fr_temp = pd.DataFrame(
+                    {"Dataset": [os.path.basename(f) for f in raw_files]},
+                )
+                fr_temp["PlexID"] = f"S{sf}"
+                fr_list.append(fr_temp)
+
+            else:
+                msg = f"Raw files not found in this folder: {subfolder}"
+                raise ValueError(msg)
+
+        return pd.concat(fr_list, ignore_index=True)
 
 
 def main():
@@ -451,16 +563,14 @@ def main():
     # Debug information
     logger.debug("\n# GENERATE PlexedPiper study_design FILES")
     logger.debug("-f: Vial metadata: %s", file_vial_metadata)
-    logger.debug("-c: Bach folder: %s", batch_folder)
+    logger.debug("-c: Batch folder: %s", batch_folder)
     logger.debug("-u: Get the raw files from: %s", raw_source)
     logger.debug("-t: tmt experiment: %s", tmt)
     logger.debug("-------------------------------------")
 
     # Collect and Generate metadata
     _batch = validate_batch(batch_folder)
-    _phase_folder = validate_phase(
-        batch_folder
-    )  # Placeholder for actual implementation
+    _phase_folder = validate_phase(batch_folder)  # Placeholder for actual implementation
     assay = validate_assay(batch_folder)  # Placeholder for actual implementation
     assay = re.sub(r"(PROT_)(.*)", r"\2", assay)
     tissue = validate_tissue(batch_folder)  # Placeholder for actual implementation
@@ -472,85 +582,55 @@ def main():
 
     date = datetime.now().strftime("%Y%m%d")
 
-    # Process batch folder
-    batch_folder = os.path.abspath(batch_folder)
+    # Process batch folder from either local folder or GCS bucket
+    is_gcs = is_gcs_path(batch_folder)
+    if is_gcs:
+        bucket_name, batch_blob_prefix = parse_gcs_path(batch_folder)
+    else:
+        batch_folder = os.path.abspath(batch_folder)
 
-    # Get RAW files folder name
-    raw_folders = glob.glob(os.path.join(batch_folder, "RAW*"))
+    # Get RAW folder from GCS bucket
+    if is_gcs:
+        # Look for "RAW*" folder under batch_blob_prefix
+        raw_folders = list_gcs_files(bucket_name, batch_blob_prefix, suffix="")
+        raw_folder_paths = [
+            re.search(r"(.*RAW[^/]+)/\d{2}MOTRPAC_", blob).group(1)
+            for blob in raw_folders
+            if re.search(r"(.*RAW[^/]+)/\d{2}MOTRPAC_", blob)
+        ]
+        if not raw_folder_paths:
+            raise ValueError("Could not detect top-level RAW folder.")
 
-    # if There is no raw folder, then use BATCH folder
-    raw_folder = batch_folder if not raw_folders else raw_folders[0]
+        raw_folder = sorted(set(raw_folder_paths))[0]
+
+    else:
+        raw_folders = glob.glob(os.path.join(batch_folder, "RAW*"))
+        raw_folder = batch_folder if not raw_folders else raw_folders[0]
 
     # Details about the tmt experiment
     if tmt == "tmt11":
         ecolnames = ["tmt_plex", "tmt11_channel", "vial_label"]
-        tmt_channels = [
-            "126C",
-            "127N",
-            "127C",
-            "128N",
-            "128C",
-            "129N",
-            "129C",
-            "130N",
-            "130C",
-            "131N",
-            "131C",
-        ]
+        tmt_channels = ["126C", "127N", "127C", "128N", "128C", "129N", "129C", "130N", "130C", "131N", "131C"]
     elif tmt == "tmt16":
         ecolnames = ["tmt_plex", "tmt16_channel", "vial_label"]
-        tmt_channels = [
-            "126C",
-            "127N",
-            "127C",
-            "128N",
-            "128C",
-            "129N",
-            "129C",
-            "130N",
-            "130C",
-            "131N",
-            "131C",
-            "132N",
-            "132C",
-            "133N",
-            "133C",
-            "134N",
-        ]
+        tmt_channels = ["126C", "127N", "127C", "128N",  "128C", "129N", "129C", "130N", "130C", "131N", "131C",
+                        "132N", "132C", "133N", "133C", "134N"]
     elif tmt == "tmt18":
         ecolnames = ["tmt_plex", "tmt18_channel", "vial_label"]
-        tmt_channels = [
-            "126C",
-            "127N",
-            "127C",
-            "128N",
-            "128C",
-            "129N",
-            "129C",
-            "130N",
-            "130C",
-            "131N",
-            "131C",
-            "132N",
-            "132C",
-            "133N",
-            "133C",
-            "134N",
-            "134C",
-            "135N",
-        ]
+        tmt_channels = ["126C", "127N", "127C", "128N", "128C", "129N", "129C", "130N", "130C", "131N", "131C",
+                        "132N", "132C", "133N", "133C", "134N",
+                        "134C", "135N"]
     else:
         msg = "<tmt> must be one of this: tmt11, tmt16, tmt18"
         raise ValueError(msg)
 
     # List all details.txt files recursively from the raw_folder
-    tmt_details_files = glob.glob(
-        os.path.join(raw_folder, "**/*details.txt"),
-        recursive=True,
-    )
-
-    # Sort the file paths to ensure they are in the correct order
-    tmt_details_files.sort()
+    if is_gcs:
+        tmt_details_files = list_gcs_files(bucket_name, raw_folder, suffix="details.txt")
+        tmt_details_files.sort()
+    else:
+        tmt_details_files = glob.glob(os.path.join(raw_folder, "**/*details.txt"), recursive=True)
+        tmt_details_files.sort()
 
     # Initialize an empty list to store data
     nm_list = []
@@ -561,7 +641,11 @@ def main():
         # Process each file
         for i, tmt_details in enumerate(tmt_details_files, 1):
             try:
-                temp = pd.read_csv(tmt_details, sep="\t")
+                if is_gcs:
+                    temp = read_gcs_tsv(bucket_name, tmt_details)
+                else:
+                    temp = pd.read_csv(tmt_details, sep="\t")
+
             except pd.errors.EmptyDataError as err:
                 msg = f"'{tmt_details}' is empty. Please validate file integrity."
                 raise ValueError(msg) from err
@@ -593,7 +677,10 @@ def main():
     else:
         logger.info("+ Reading file vial metadata")
         try:
-            vial_metadata = pd.read_csv(file_vial_metadata, sep="\t")
+            if is_gcs:
+                vial_metadata = read_gcs_tsv(bucket_name, file_vial_metadata)
+            else:
+                vial_metadata = pd.read_csv(file_vial_metadata, sep="\t")
             if vial_metadata.empty:
                 msg = f"{file_vial_metadata} is empty. Please use generate option to generate vial metadata file."
                 raise ValueError(msg)
@@ -712,11 +799,12 @@ def main():
         fractions = process_manifest(raw_folder)
 
     elif raw_source == "folder":
-        fractions = process_folder(raw_folder)
+        fractions = process_folder(raw_folder, is_gcs=is_gcs, bucket_name=bucket_name if is_gcs else None)
+
     else:
         msg = "The -s argument is not right. It should be either `manifest` or `folder`"
         raise ValueError(msg)
-
+    
     fractions["Dataset"] = fractions["Dataset"].str.replace(".raw", "")
 
     logger.info("+ Checking PlexID notations")
@@ -749,7 +837,10 @@ def main():
     # The study_design folder should be in the RAW folder, but given that in
     # some cases the RAW files were not given in the RAW folder, it might be
     # located in the BATCH folder.
-    output_viallabel_name = os.path.join(raw_folder, "study_design")
+    if is_gcs:
+        output_viallabel_name = os.path.join(args.output_dir, "study_design")
+    else:
+        output_viallabel_name = os.path.join(raw_folder, "study_design")
 
     if not os.path.exists(output_viallabel_name):
         os.makedirs(output_viallabel_name, exist_ok=True)

--- a/scripts/create_study_design.py
+++ b/scripts/create_study_design.py
@@ -672,6 +672,15 @@ def main():
                 lambda x: f"Ref_S{i}" if "Ref" in str(x) else x,
             )
 
+            # Check for multiple Ref entries in a single TMTdetails file
+            num_ref = temp["vial_label"].str.startswith("Ref_S").sum()
+            if num_ref > 1:
+                raise ValueError(
+                    f"❌ '{tmt_details}' contains {num_ref} vial_label entries starting with 'Ref'.\n"
+                    f"Only one reference sample is allowed per TMTdetails file.\n"
+                    f"Please check the file: {tmt_details}"
+                )
+
             nm_list.append(temp)
 
         vial_metadata = pd.concat(nm_list, ignore_index=True)

--- a/scripts/create_study_design.py
+++ b/scripts/create_study_design.py
@@ -1,0 +1,520 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import re
+import argparse
+import pandas as pd
+import numpy as np
+from datetime import datetime
+import glob
+import warnings
+
+
+def validate_batch(input_results_folder):
+    """
+    Extract BATCH_YYYYMMDD folder from input folder path.
+
+    Args:
+        input_results_folder (str): input_results_folder path
+
+    Returns:
+        str: BATCH_YYYYMMDD folder name
+
+    Raises:
+        ValueError: If batch folder is not recognized
+    """
+    # Try different patterns to be more flexible
+    # First try the original pattern
+    batch_match = re.search(r".*/?(BATCH\d{1,2}\_\d{8})", input_results_folder)
+
+    if not batch_match:
+        # Try alternative pattern without requiring a path before BATCH
+        batch_match = re.search(r"(BATCH\d{1,2}\_\d{8})", input_results_folder)
+
+    if not batch_match:
+        raise ValueError("`BATCH#_YYYYMMDD` folder is not recognized in the folder structure.")
+    else:
+        return batch_match.group(1)
+
+
+def validate_phase(input_results_folder, return_phase=True):
+    """
+    Extract PHASE from input folder path.
+
+    Args:
+        input_results_folder (str): input_results_folder path
+        return_phase (bool): return the phase only if True (default)
+
+    Returns:
+        str: PHASE code
+
+    Raises:
+        ValueError: If phase is not found in the folder structure
+    """
+    phase = re.search(
+        r"(PASS1A-06|PASS1A-18|PASS1B-06|PASS1B-18|PASS1C-06|PASS1C-18|PASS1AC-06|HUMAN|HUMAN-PRECOVID|HUMAN-MAIN)",
+        input_results_folder)
+
+    if not phase:
+        raise ValueError(
+            "- (-) Project phase is not found in the folder structure. Please, check the MoTrPAC control vocabulary guidelines")
+    else:
+        if return_phase:
+            return phase.group(1)
+
+
+def validate_assay(input_results_folder):
+    """
+    Extract ASSAY from input folder path.
+
+    Args:
+        input_results_folder (str): input_results_folder path
+
+    Returns:
+        str: ASSAY code
+
+    Raises:
+        ValueError: If assay is not found
+    """
+    assay = re.search(
+        r"(?<=T\d{2}/)(IONPNEG|RPNEG|RPPOS|HILICPOS|LRPPOS|LRPNEG|3HIB|AA|AC_DUKE|ACOA|BAIBA|CER_DUKE|KA|NUC|OA|SPHM|OXYLIPNEG|ETAMIDPOS|AC_MAYO|AMINES|CER_MAYO|TCA|LAB_GLC|LAB_INS|PROT_PH|PROT_PR|PROT_AC|PROT_UB|PROT_OL|PROT_OX|LAB_CK|LAB_CRT|LAB_CONV)",
+        input_results_folder
+    )
+
+    if not assay:
+        raise ValueError("ASSAY not found in the folder structure")
+    else:
+        return assay.group(0)
+
+
+def validate_tissue(input_results_folder):
+    """
+    Extract and validate TISSUE CODE from input folder path.
+
+    Args:
+        input_results_folder (str): input_results_folder path
+
+    Returns:
+        str: Tissue code
+
+    Raises:
+        ValueError: If tissue code is not valid
+    """
+    # Define the list of valid tissue codes as in bic_animal_tissue_code$bic_tissue_code
+    bic_tissue_codes = [
+        "T01", "T02", "T03", "T04", "T05", "T06", "T07", "T08", "T09", "T10",
+        "T11", "T12", "T13", "T14", "T15", "T16", "T17", "T18", "T19", "T20",
+        "T21", "T30", "T31", "T32", "T33", "T34", "T35", "T36", "T37", "T38",
+        "T39", "T40", "T41", "T42", "T43", "T44", "T45", "T46", "T47", "T48",
+        "T49", "T50", "T51", "T52", "T53", "T54", "T55", "T56", "T57", "T58",
+        "T59", "T60", "T61", "T62", "T63", "T64", "T65", "T66", "T67", "T68",
+        "T69", "T70", "T77", "T99"
+    ]
+
+    # Extract tissue code using regex similar to gsub in R
+    match = re.search(r"(.*)(T[0-9]{2,3})(.*)", input_results_folder)
+    if not match:
+        raise ValueError("Tissue code not found in the folder structure")
+
+    tissue_code = match.group(2)
+
+    if tissue_code not in bic_tissue_codes:
+        raise ValueError(
+            f"tissue_code: `{tissue_code}` is not valid. Must be one of the following codes "
+            f"(check data object `MotrpacBicQC::bic_animal_tissue_code`):\n- {', '.join(bic_tissue_codes)}"
+        )
+    else:
+        return tissue_code
+
+
+def find_unique_tmt_channel(tempcol):
+    """
+    Find unique TMT channel name in a list based on a specified pattern.
+
+    Args:
+        tempcol: A list of potential TMT channel names.
+
+    Returns:
+        The matching TMT channel name if exactly one match is found.
+        Raises error if no matches or multiple matches are found.
+    """
+    # Check that input is a list/array-like
+    if not isinstance(tempcol, (list, np.ndarray, pd.Series)):
+        raise ValueError("Input must be a list-like object.")
+
+    # Regular expression to find matches
+    pattern = r"^tmt(\d{2})?_channel$"
+
+    # Find matches
+    matches = [col for col in tempcol if re.match(pattern, col)]
+
+    # Check the number of matches
+    if len(matches) == 1:
+        # Return the matching variable
+        return matches[0]
+    elif len(matches) > 1:
+        raise ValueError("Error: More than one matching element found.")
+    else:
+        raise ValueError("Error: No matching elements found.")
+
+
+def check_tmt_channels(tmt_type, tmt_expected, temp, tmt_col, tmt_details):
+    """
+    Check TMT channel consistency and provide detailed comparison.
+
+    Args:
+        tmt_type: Type of TMT experiment
+        tmt_expected: List of expected TMT channels
+        temp: DataFrame with TMT data
+        tmt_col: Column name containing TMT channels
+        tmt_details: Path to TMT details file for error reporting
+
+    Raises:
+        ValueError if channel mismatch is detected
+    """
+    actual_channels = sorted(temp[tmt_col].tolist())
+    expected_channels = sorted(tmt_expected)
+
+    if expected_channels != actual_channels:
+        # Find differences and intersections
+        shared_channels = set(expected_channels).intersection(set(actual_channels))
+        missed_in_actual = set(expected_channels).difference(set(actual_channels))
+        extra_in_actual = set(actual_channels).difference(set(expected_channels))
+
+        # Build error message
+        error_message = (
+            f"Something is wrong: the expected `{tmt_type}` channels and the `{tmt_type}` "
+            f"channels available in the `{os.path.basename(tmt_details)}` file do not match."
+            f"\nThis likely means that there is a mismatch between the tmt specified as argument and the actual channels available in the data files.\n"
+        )
+
+        if shared_channels:
+            error_message += f"\nShared channels: {', '.join(shared_channels)}"
+        if missed_in_actual:
+            error_message += f"\nMissing in actual data: {', '.join(missed_in_actual)}"
+        if extra_in_actual:
+            error_message += f"\nExtra in actual data: {', '.join(extra_in_actual)}"
+
+        raise ValueError(error_message)
+
+
+def fix_duplicates(meta):
+    """Fix duplicated vial_labels by making them unique."""
+    if meta['vial_label'].duplicated().any():
+        warnings.warn("Duplicate vial_label ids found. Making unique ids.")
+        # Equivalent to R's make.unique
+        seen = {}
+        unique_names = []
+        for name in meta['vial_label']:
+            if name in seen:
+                seen[name] += 1
+                unique_names.append(f"{name}.{seen[name]}")
+            else:
+                seen[name] = 0
+                unique_names.append(name)
+        meta['vial_label'] = unique_names
+    return meta
+
+
+def main():
+    # Set up command line argument parser
+    parser = argparse.ArgumentParser(description='Generate PlexedPiper study_design files')
+
+    parser.add_argument('-f', '--file_vial_metadata', type=str, default='generate',
+                        help='File <-vial_metadata.txt> or type <generate> if it does not exist')
+    parser.add_argument('-b', '--batch_folder', type=str, required=True,
+                        help='Full path to the BATCH folder (from the PHASE folder)')
+    parser.add_argument('-c', '--cas', type=str, required=True,
+                        help='CAS: BI or PN)')
+    parser.add_argument('-s', '--raw_source', type=str, default='folder',
+                        help='Source to get the raw files: `manifest` from manifest file or `folder` to list them from the bucket raw folders')
+    parser.add_argument('-t', '--tmt', type=str, required=True,
+                        help='One of the following options: tmt11, tmt16, tmt18')
+    parser.add_argument('-p', '--phase', type=str, required=True,
+                        help='MOTRPAC PHASE')
+
+    # Parse arguments
+    args = parser.parse_args()
+
+    # Extract arguments for easier access
+    file_vial_metadata = args.file_vial_metadata
+    batch_folder = args.batch_folder
+    cas = args.cas
+    raw_source = args.raw_source
+    tmt = args.tmt
+    phase = args.phase
+
+    # Debug information
+    print("\n# GENERATE PlexedPiper study_design FILES")
+    print(f"-f: Vial metadata: {file_vial_metadata}")
+    print(f"-c: Bach folder: {batch_folder}")
+    print(f"-u: Get the raw files from: {raw_source}")
+    print(f"-t: tmt experiment: {tmt}")
+    print("-------------------------------------")
+
+    # Collect and Generate metadata
+    batch = validate_batch(batch_folder)
+    phase_folder = validate_phase(batch_folder)  # Placeholder for actual implementation
+    assay = validate_assay(batch_folder)  # Placeholder for actual implementation
+    assay = re.sub(r"(PROT_)(.*)", r"\2", assay)
+    tissue = validate_tissue(batch_folder)  # Placeholder for actual implementation
+
+    valid_cas = ["PN", "BI", "PNBI"]
+    if cas not in valid_cas:
+        raise ValueError(f"<cas> must be one of this: {','.join(valid_cas)}")
+
+    date = datetime.now().strftime("%Y%m%d")
+
+    # Process batch folder
+    batch_folder = os.path.abspath(batch_folder)
+
+    # Get RAW files folder name
+    raw_folders = glob.glob(os.path.join(batch_folder, "RAW*"))
+
+    if not raw_folders:
+        # if There is no raw folder, then use BATCH folder
+        raw_folder = batch_folder
+    else:
+        raw_folder = raw_folders[0]
+
+    # Details about the tmt experiment
+    if tmt == "tmt11":
+        ecolnames = ["tmt_plex", "tmt11_channel", "vial_label"]
+        tmt11 = ["126C", "127N", "127C", "128N", "128C", "129N", "129C", "130N", "130C", "131N", "131C"]
+    elif tmt == "tmt16":
+        ecolnames = ["tmt_plex", "tmt16_channel", "vial_label"]
+        tmt16 = ["126C", "127N", "127C", "128N", "128C", "129N", "129C", "130N", "130C", "131N", "131C", "132N", "132C",
+                 "133N", "133C", "134N"]
+    elif tmt == "tmt18":
+        ecolnames = ["tmt_plex", "tmt18_channel", "vial_label"]
+        tmt18 = ["126C", "127N", "127C", "128N", "128C", "129N", "129C", "130N", "130C", "131N", "131C", "132N", "132C",
+                 "133N", "133C", "134N", "134C", "135N"]
+    else:
+        raise ValueError("<tmt> must be one of this: tmt11, tmt16, tmt18")
+
+    # List all details.txt files recursively from the raw_folder
+    tmt_details_files = glob.glob(os.path.join(raw_folder, "**/*details.txt"), recursive=True)
+
+    # Sort the file paths to ensure they are in the correct order
+    tmt_details_files.sort()
+
+    # Initialize an empty list to store data
+    nm_list = []
+
+    if file_vial_metadata == "generate":
+        print("+ Generate vial metadata file")
+
+        # Process each file
+        for i, tmt_details in enumerate(tmt_details_files, 1):
+            temp = pd.read_csv(tmt_details, sep='\t')
+
+            tmt_col = find_unique_tmt_channel(temp.columns.tolist())
+
+            # Check TMT channels based on tmt type
+            if tmt == "tmt11":
+                check_tmt_channels(tmt, tmt11, temp, tmt_col, tmt_details)
+            elif tmt == "tmt16":
+                check_tmt_channels(tmt, tmt16, temp, tmt_col, tmt_details)
+            elif tmt == "tmt18":
+                check_tmt_channels(tmt, tmt18, temp, tmt_col, tmt_details)
+
+            # Add custom labels
+            temp['tmt_plex'] = f"S{i}"
+            temp['vial_label'] = temp['vial_label'].apply(lambda x: f"Ref_S{i}" if "Ref" in str(x) else x)
+
+            nm_list.append(temp)
+
+        vial_metadata = pd.concat(nm_list, ignore_index=True)
+        file_vial_metadata = f"MOTRPAC_{phase}_{tissue}_{assay}_{cas}_{date}_vial_metadata.txt"
+    else:
+        print("+ Reading file vial metadata")
+        vial_metadata = pd.read_csv(file_vial_metadata, sep='\t')
+        file_vial_metadata = f"MOTRPAC_{phase}_{tissue}_{assay}_{cas}_{date}_vial_metadata.txt"
+
+    print(f"\t - File name: {file_vial_metadata}")
+
+    # Make adjustments: make sure that the Reference channel is "Ref_S#"
+    vial_metadata.columns = vial_metadata.columns.str.lower()
+    vial_metadata['vial_label'] = vial_metadata.apply(
+        lambda row: f"Ref_{row['tmt_plex']}" if re.match(r"^ref", str(row['vial_label']), re.IGNORECASE) else row[
+            'vial_label'],
+        axis=1
+    )
+
+    # Check if there are any "Ref" samples
+    has_ref = any(vial_metadata['vial_label'].str.contains(r"^Ref", case=False, regex=True))
+
+    if not all(col in vial_metadata.columns for col in ecolnames):
+        missing = [col for col in ecolnames if col not in vial_metadata.columns]
+        raise ValueError(f"Vial Metadata. The expected column names...\n\t{', '.join(ecolnames)}\n"
+                         f"are not available in vial_metadata: \n\t{', '.join(vial_metadata.columns)}\n"
+                         f"Missing columns: {', '.join(missing)}")
+
+    # Remove white spaces (known issue for pnnl submissions)
+    vial_metadata['vial_label'] = vial_metadata['vial_label'].str.replace(" ", "")
+
+    # Fix duplicated vial_labels
+    vial_metadata = fix_duplicates(meta=vial_metadata)
+
+    # Generate samples.txt
+    print("+ Generate samples.txt... ", end="")
+
+    if tmt == "tmt11":
+        samples = vial_metadata.copy()
+        samples['PlexID'] = samples['tmt_plex']
+        samples['QuantBlock'] = 1
+        samples['ReporterName'] = samples['tmt11_channel']
+        samples['ReporterAlias'] = samples['vial_label']
+        samples['MeasurementName'] = samples['vial_label']
+        samples = samples.drop(['tmt_plex', 'tmt11_channel', 'vial_label'], axis=1)
+    elif tmt == "tmt16":
+        samples = vial_metadata.copy()
+        samples['PlexID'] = samples['tmt_plex']
+        samples['QuantBlock'] = 1
+        samples['ReporterName'] = samples['tmt16_channel']
+        samples['ReporterAlias'] = samples['vial_label']
+        samples['MeasurementName'] = samples['vial_label']
+        samples = samples.drop(['tmt_plex', 'tmt16_channel', 'vial_label'], axis=1)
+    elif tmt == "tmt18":
+        samples = vial_metadata.copy()
+        samples['PlexID'] = samples['tmt_plex']
+        samples['QuantBlock'] = 1
+        samples['ReporterName'] = samples['tmt18_channel']
+        samples['ReporterAlias'] = samples['vial_label']
+        samples['MeasurementName'] = samples['vial_label']
+        samples = samples.drop(['tmt_plex', 'tmt18_channel', 'vial_label'], axis=1)
+
+    # adjustments
+    samples['ReporterName'] = samples['ReporterName'].str.replace("126C", "126")
+
+    if has_ref:
+        samples['MeasurementName'] = samples['ReporterAlias']
+        ref_mask = samples['ReporterAlias'].str.contains(r"^ref", case=False, regex=True)
+        samples.loc[ref_mask, 'MeasurementName'] = None
+
+    # Select only required columns
+    samples = samples[["PlexID", "QuantBlock", "ReporterName", "ReporterAlias", "MeasurementName"]]
+
+    print("done")
+
+    # Generate references.txt
+    print("+ Generate references... ", end="")
+
+    # Conditional operation based on the presence of "Ref" samples
+    if has_ref:
+        references = samples[samples['ReporterAlias'].str.contains(r"^\+?Ref", regex=True)].copy()
+        references = references.drop(['ReporterName', 'MeasurementName'], axis=1)
+        references = references.rename(columns={'ReporterAlias': 'Reference'})
+    else:
+        print("(no references available: value 1 would be added instead) ", end="")
+        references = samples[['PlexID', 'QuantBlock']].copy()
+        references['Reference'] = 1
+
+    print("done")
+
+    # Generate fractions.txt
+    print("+ Generate fractions.txt file ", end="")
+    fractions = None
+
+    if raw_source == "manifest":
+        print("(from processing manifest files):")
+        file_manifest = glob.glob(os.path.join(raw_folder, "**/*metadata_file.txt"), recursive=True)
+        file_manifest.extend(glob.glob(os.path.join(raw_folder, "**/*raw_metadata_file*"), recursive=True))
+
+        # Sort the file paths to ensure they are in the correct order
+        file_manifest.sort()
+
+        for i, manifest_file in enumerate(file_manifest, 1):
+            print(f"\t{i}. File: {os.path.basename(manifest_file)}")
+
+            manifest = pd.read_csv(manifest_file, sep='\t')
+
+            manifest = manifest[['file_name']]
+            manifest = manifest.rename(columns={'file_name': 'Dataset'})
+
+            manifest['PlexID'] = f"S{i}"
+
+            if fractions is None:
+                fractions = manifest
+            else:
+                fractions = pd.concat([fractions, manifest], ignore_index=True)
+
+    elif raw_source == "folder":
+        print("(from listing raw files in folder)")
+
+        # Check subfolders
+        raw_subfolders = [f for f in glob.glob(os.path.join(raw_folder, "**/")) if re.search(r".*/\d{2}.*", f)]
+        raw_subfolders.sort()
+
+        if not raw_subfolders:
+            raise ValueError(
+                "The number of subfolders with raw data is equal to 0, which might mean that this submission is not according to MoTrPAC guidelines")
+
+        fr_list = []
+        for sf, subfolder in enumerate(raw_subfolders, 1):
+            raw_files = glob.glob(os.path.join(subfolder, "**/*.raw"), recursive=True)
+
+            if raw_files:
+                fr_temp = pd.DataFrame({'Dataset': [os.path.basename(f) for f in raw_files]})
+                fr_temp['PlexID'] = f"S{sf}"
+                fr_list.append(fr_temp)
+            else:
+                raise ValueError(f"\n\nRaw files not found in this folder:\n{subfolder}")
+
+        fractions = pd.concat(fr_list, ignore_index=True)
+
+    else:
+        raise ValueError("The -s argument is not right. It should be either `manifest` or `folder`")
+
+    fractions['Dataset'] = fractions['Dataset'].str.replace(".raw", "")
+
+    print("+ Checking PlexID notations")
+    # Extract unique and sorted values from each data frame's relevant variable
+    unique_fractions = sorted(fractions['PlexID'].unique())
+    unique_samples = sorted(samples['PlexID'].unique())
+    unique_references = sorted(references['PlexID'].unique())
+    unique_vial_metadata = sorted(vial_metadata['tmt_plex'].unique())
+
+    # Compare all vectors for equality
+    are_equal = (unique_fractions == unique_samples and
+                 unique_samples == unique_references and
+                 unique_references == unique_vial_metadata)
+
+    # Output the result
+    if are_equal:
+        print("+ Validations: All PlexID lists are identical.")
+    else:
+        print("Not all PlexID lists are identical. Detailed comparison needed.")
+        print(f"Fractions PlexID: {','.join(unique_fractions)}")
+        print(f"Samples PlexID: {','.join(unique_samples)}")
+        print(f"References PlexID: {','.join(unique_references)}")
+        print(f"Vial Metadata tmt_plex: {','.join(unique_vial_metadata)}")
+        raise ValueError("Fix PlexID before printing out files")
+
+    # Print out files
+    # The study_design folder should be in the RAW folder, but given that in
+    # some cases the RAW files were not given in the RAW folder, it might be
+    # located in the BATCH folder.
+    output_viallabel_name = os.path.join(raw_folder, "study_design")
+
+    if not os.path.exists(output_viallabel_name):
+        os.makedirs(output_viallabel_name, exist_ok=True)
+
+    fractions.to_csv(os.path.join(output_viallabel_name, "fractions.txt"),
+                     sep='\t', index=False)
+
+    references.to_csv(os.path.join(output_viallabel_name, "references.txt"),
+                      sep='\t', index=False)
+
+    samples.to_csv(os.path.join(output_viallabel_name, "samples.txt"),
+                   sep='\t', index=False)
+
+    vial_metadata.to_csv(os.path.join(output_viallabel_name, file_vial_metadata),
+                         sep='\t', index=False)
+
+    print(f"\nAll files are out! Check them out at:\n{output_viallabel_name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/create_study_design.py
+++ b/scripts/create_study_design.py
@@ -423,46 +423,74 @@ def process_folder(raw_folder: str, is_gcs: bool = False, bucket_name: str = Non
             if not non_empty_raw_files:
                 raise ValueError(f"No valid .raw files in GCS subfolder: {subfolder_prefix}")
 
-            # Validate filenames
-            invalid_files = [
-                blob.name for blob in non_empty_raw_files
-                if not re.search(r"_f(r)?\d{2,3}\.raw$", os.path.basename(blob.name))
-            ]
+            # Validate filenames (accept *_f{nn}.raw, *_fr{nn}.raw, *_f{nn}_{x}.raw, *_fr{nn}_{x}.raw)
+            invalid_files = []
+            nonstandard_files = []
 
+            for blob in non_empty_raw_files:
+                filename = os.path.basename(blob.name)
+                if re.search(r"_f(r)?\d{2,3}\.raw$", filename):
+                    continue  # standard
+                elif re.search(r"_f(r)?\d{2,3}_.+\.raw$", filename):
+                    nonstandard_files.append(blob.name)  # accepted, but nonstandard
+                else:
+                    invalid_files.append(blob.name)  # invalid
+            
+            # Raise error if any file is truly invalid
             if invalid_files:
-                    msg = f"The following raw files do not follow the format of proposed file name: {'\n'.join(invalid_files)}. \n\nPlease check the MoTrPAC control vocabulary guidelines.\n"
-                    raise ValueError(msg)
+                msg = (
+                    f"The following raw files do not follow any accepted naming format:\n"
+                    f"{chr(10).join(invalid_files)}\n\n"
+                    f"Please check the MoTrPAC control vocabulary guidelines.\n"
+                )
+                raise ValueError(msg)
+
+            # Warn if nonstandard files are used
+            if nonstandard_files:
+                logger.warning(
+                    "⚠️ The following raw files use nonstandard naming (e.g. *_f{nn}_{x}.raw):\n%s\n"
+                    "These will be processed, but it's recommended to rename them to *_f{nn}.raw or *_fr{nn}.raw for future submissions.\n",
+                    "\n".join(nonstandard_files)
+                )
 
             # Extract fraction numbers
             fraction_nums = []
             for blob in non_empty_raw_files:
-                match = re.search(r"_f(?:r)?(\d{2,3})\.raw$", os.path.basename(blob.name))
+                filename = os.path.basename(blob.name)
+                match = re.search(r"_f(?:r)?(\d{2,3})(?:_.+)?\.raw$", filename)
                 if match:
                     fraction_nums.append(int(match.group(1)))
-
+            
             if fraction_nums:
                 min_frac = min(fraction_nums)
                 max_frac = max(fraction_nums)
                 expected_fracs = set(range(min_frac, max_frac + 1))
                 actual_fracs = set(fraction_nums)
                 missing_fracs = sorted(expected_fracs - actual_fracs)
-
+                    
                 if missing_fracs:
                     all_basenames = {os.path.basename(b.name) for b in non_empty_raw_files}
-                    sample_prefix = os.path.splitext(os.path.basename(non_empty_raw_files[0].name))[0].rsplit("_f", 1)[0]
+                    
+                    # Extract sample_prefix from first file (remove _f{nn} or _fr{nn} and optional _{timestamp})
+                    first_base = os.path.splitext(os.path.basename(non_empty_raw_files[0].name))[0]
+                    match = re.search(r"(.*)_f(r)?\d{2,3}(?:_.+)?$", first_base)
+                    sample_prefix = match.group(1) if match else first_base
                     has_fr = "_fr" in os.path.basename(non_empty_raw_files[0].name)
                     suffix = "fr" if has_fr else "f"
+
+                    # Build expected filenames (standard naming only)
                     expected_names = {
                         f"{sample_prefix}_{suffix}{str(i).zfill(2)}.raw"
                         for i in range(min_frac, max_frac + 1)
                     }
+
+                    # Compare against raw file basenames
                     missing_names = sorted(expected_names - all_basenames)
 
                     logger.warning(
                         "🚨 Warning: Missing fractions in %s. Expected f%02d to f%02d.\nMissing files:\n%s",
                         subfolder_prefix, min_frac, max_frac, "\n".join(missing_names)
                     )
-                    
 
             fr_temp = pd.DataFrame({
                 "Dataset": [os.path.basename(blob.name) for blob in non_empty_raw_files]
@@ -515,18 +543,38 @@ def process_folder(raw_folder: str, is_gcs: bool = False, bucket_name: str = Non
             raw_files = non_empty_raw_files
 
             if raw_files:
-                invalid_files = [
-                    f for f in raw_files
-                    if not re.search(r"_f(r)?\d{2,3}\.raw$", os.path.basename(f))
-                ]
+                invalid_files = []
+                nonstandard_files = []
+
+                for f in raw_files:
+                    filename = os.path.basename(f)
+                    if re.search(r"_f(r)?\d{2,3}\.raw$", filename):
+                        continue  # Standard
+                    elif re.search(r"_f(r)?\d{2,3}_.+\.raw$", filename):
+                        nonstandard_files.append(f)
+                    else:
+                        invalid_files.append(f)
+
                 if invalid_files:
-                    msg = f"The following raw files do not follow the format of proposed file name: {'\n'.join(invalid_files)}. \n\nPlease check the MoTrPAC control vocabulary guidelines.\n"
+                    msg = (
+                        f"The following raw files do not follow any accepted naming format:\n"
+                        f"{chr(10).join(invalid_files)}\n\n"
+                        f"Please check the MoTrPAC control vocabulary guidelines.\n"
+                    )
                     raise ValueError(msg)
+
+                if nonstandard_files:
+                    logger.warning(
+                        "⚠️ The following raw files use nonstandard naming (e.g. *_f{nn}_{x}.raw):\n%s\n"
+                        "These will be processed, but should be renamed to *_f{nn}.raw or *_fr{nn}.raw in future.\n",
+                        "\n".join(nonstandard_files)
+                    )
 
                 # Extract fraction numbers from filenames
                 fraction_nums = []
                 for f in raw_files:
-                    match = re.search(r"_f(?:r)?(\d{2,3})\.raw$", os.path.basename(f))
+                    filename = os.path.basename(f)
+                    match = re.search(r"_f(?:r)?(\d{2,3})(?:_.+)?\.raw$", filename)
                     if match:
                         fraction_nums.append(int(match.group(1)))
 
@@ -537,32 +585,40 @@ def process_folder(raw_folder: str, is_gcs: bool = False, bucket_name: str = Non
                     actual_fracs = set(fraction_nums)
                     missing_fracs = sorted(expected_fracs - actual_fracs)
 
+
                     if missing_fracs:
                         all_basenames = {os.path.basename(f) for f in raw_files}
-                        sample_prefix = os.path.splitext(os.path.basename(raw_files[0]))[0].rsplit("_f", 1)[0]
+
+                        # Extract sample prefix, stripping suffix _fNN_{x} or _frNN_{x}
+                        first_base = os.path.splitext(os.path.basename(raw_files[0]))[0]
+                        match = re.search(r"(.*)_f(r)?\d{2,3}(?:_.+)?$", first_base)
+                        sample_prefix = match.group(1) if match else first_base
                         has_fr = "_fr" in os.path.basename(raw_files[0])
                         suffix = "fr" if has_fr else "f"
+
+                        # Expected names use only standard format
                         expected_names = {
                             f"{sample_prefix}_{suffix}{str(i).zfill(2)}.raw"
                             for i in range(min_frac, max_frac + 1)
                         }
+
                         missing_names = sorted(expected_names - all_basenames)
 
                         logger.warning(
                             "🚨 Warning: Missing fraction files in %s. Expected fractions from f%s to f%s.\n"
-                            "Missing files:\n %s \nContinuing with available files.\n",
+                            "Missing files:\n%s\nContinuing with available files.\n",
                             subfolder,
                             str(min_frac).zfill(2),
                             str(max_frac).zfill(2),
-                            "\n ".join(missing_names),
+                            "\n".join(missing_names),
                         )
 
-                fr_temp = pd.DataFrame(
-                    {"Dataset": [os.path.basename(f) for f in raw_files]},
-                )
+                # Construct dataframe of observed files
+                fr_temp = pd.DataFrame({
+                    "Dataset": [os.path.basename(f) for f in raw_files]
+                })
                 fr_temp["PlexID"] = f"S{sf}"
                 fr_list.append(fr_temp)
-
             else:
                 msg = f"Raw files not found in this folder: {subfolder}"
                 raise ValueError(msg)
@@ -789,7 +845,7 @@ def main():
 
     if has_ref:
         samples["MeasurementName"] = samples["ReporterAlias"]
-        # Matches values in the "ReporterAlias" column that start with "Ref" or "ref" (case-insensitive)
+        # Matches values in the "ReporterAlias" column that starts with "Ref" or "ref" (case-insensitive)
         ref_mask = samples["ReporterAlias"].str.contains(r"^ref", case=False, regex=True)
         samples.loc[ref_mask, "MeasurementName"] = "NA"
 

--- a/scripts/create_study_design.py
+++ b/scripts/create_study_design.py
@@ -10,7 +10,6 @@ from datetime import datetime
 import glob
 import warnings
 
-
 def validate_batch(input_results_folder):
     """
     Extract BATCH_YYYYMMDD folder from input folder path.
@@ -53,12 +52,12 @@ def validate_phase(input_results_folder, return_phase=True):
         ValueError: If phase is not found in the folder structure
     """
     phase = re.search(
-        r"(PASS1A-06|PASS1A-18|PASS1B-06|PASS1B-18|PASS1C-06|PASS1C-18|PASS1AC-06|HUMAN|HUMAN-PRECOVID|HUMAN-MAIN)",
+        r"(PASS1A-06|PASS1A-18|PASS1B-06|PASS1B-18|PASS1C-06|PASS1C-18|PASS1AC-06|HUMAN|HUMAN-PRECOVID|HUMAN-MAIN-TR(?:0[1-9]|1[0-5]))",
         input_results_folder)
 
     if not phase:
         raise ValueError(
-            "- (-) Project phase is not found in the folder structure. Please, check the MoTrPAC control vocabulary guidelines")
+            "- (-) Project phase is not found in the folder structure. Please check the MoTrPAC control vocabulary guidelines")
     else:
         if return_phase:
             return phase.group(1)
@@ -284,12 +283,10 @@ def main():
         tmt11 = ["126C", "127N", "127C", "128N", "128C", "129N", "129C", "130N", "130C", "131N", "131C"]
     elif tmt == "tmt16":
         ecolnames = ["tmt_plex", "tmt16_channel", "vial_label"]
-        tmt16 = ["126C", "127N", "127C", "128N", "128C", "129N", "129C", "130N", "130C", "131N", "131C", "132N", "132C",
-                 "133N", "133C", "134N"]
+        tmt16 = ["126C", "127N", "127C", "128N", "128C", "129N", "129C", "130N", "130C", "131N", "131C", "132N", "132C", "133N", "133C", "134N"]
     elif tmt == "tmt18":
         ecolnames = ["tmt_plex", "tmt18_channel", "vial_label"]
-        tmt18 = ["126C", "127N", "127C", "128N", "128C", "129N", "129C", "130N", "130C", "131N", "131C", "132N", "132C",
-                 "133N", "133C", "134N", "134C", "135N"]
+        tmt18 = ["126C", "127N", "127C", "128N", "128C", "129N", "129C", "130N", "130C", "131N", "131C", "132N", "132C", "133N", "133C", "134N", "134C", "135N"]
     else:
         raise ValueError("<tmt> must be one of this: tmt11, tmt16, tmt18")
 
@@ -307,7 +304,13 @@ def main():
 
         # Process each file
         for i, tmt_details in enumerate(tmt_details_files, 1):
-            temp = pd.read_csv(tmt_details, sep='\t')
+            try:
+                temp = pd.read_csv(tmt_details, sep='\t')
+            except pd.errors.EmptyDataError:
+                raise ValueError(f"ERROR: '{tmt_details}' is empty. Please validate file integrity.")
+
+            if temp.empty or temp.shape[1] == 0:
+                raise ValueError(f"ERROR: '{tmt_details}' contains no data. Please validate file integrity.")
 
             tmt_col = find_unique_tmt_channel(temp.columns.tolist())
 
@@ -327,9 +330,16 @@ def main():
 
         vial_metadata = pd.concat(nm_list, ignore_index=True)
         file_vial_metadata = f"MOTRPAC_{phase}_{tissue}_{assay}_{cas}_{date}_vial_metadata.txt"
+
     else:
         print("+ Reading file vial metadata")
-        vial_metadata = pd.read_csv(file_vial_metadata, sep='\t')
+        try:
+            vial_metadata = pd.read_csv(file_vial_metadata, sep='\t')
+            if vial_metadata.empty:
+                raise ValueError(f"{file_vial_metadata} is empty. Please use generate option to generate vial metadata file.")
+        except pd.errors.EmptyDataError:
+            raise ValueError(f"{file_vial_metadata} is empty. Please use generate option to generate vial metadata file.")
+        
         file_vial_metadata = f"MOTRPAC_{phase}_{tissue}_{assay}_{cas}_{date}_vial_metadata.txt"
 
     print(f"\t - File name: {file_vial_metadata}")
@@ -455,10 +465,71 @@ def main():
         for sf, subfolder in enumerate(raw_subfolders, 1):
             raw_files = glob.glob(os.path.join(subfolder, "**/*.raw"), recursive=True)
 
+            # Check and exclude empty *raw files
+            non_empty_raw_files = []
+            empty_raw_files = []
+
+            for raw_file in raw_files:
+                try:
+                    with open(raw_file, "rb") as f:  # binary mode just in case
+                        first_line = f.readline()
+                        if first_line.strip():  # non-empty
+                            non_empty_raw_files.append(raw_file)
+                        else:
+                            empty_raw_files.append(os.path.basename(raw_file))
+                except Exception as e:
+                    print(f"⚠️ Could not read {raw_file}: {e}")
+                    empty_raw_files.append(os.path.basename(raw_file))
+
+            if empty_raw_files:
+                print(
+                    f"\n🚨 Warning: The following raw files in {subfolder} appears to be empty:\n "
+                    + " \n    ".join(empty_raw_files)
+                    + "\n  Please inspect for issues. Analysis will continue with non-empty files.\n"
+                )
+
+            # Use only non-empty files going forward
+            raw_files = non_empty_raw_files
+
             if raw_files:
+                invalid_files = [f for f in raw_files if not re.search(r"_f\d{2,3}\.raw$", os.path.basename(f))]
+                if invalid_files:
+                    raise ValueError(
+                        f"\nThe following raw files do not follow the format of proposed file name:\n" +
+                        "\n".join(invalid_files) +
+                        "\n\nPlease check the MoTrPAC control vocabulary guidelines.\n"
+                    )
+                
+                # Extract fraction numbers from filenames
+                fraction_nums = []
+                for f in raw_files:
+                    match = re.search(r"_f(\d{2,3})\.raw$", os.path.basename(f))
+                    if match:
+                        fraction_nums.append(int(match.group(1)))
+
+                if fraction_nums:
+                    min_frac = min(fraction_nums)
+                    max_frac = max(fraction_nums)
+                    expected_fracs = set(range(min_frac, max_frac + 1))
+                    actual_fracs = set(fraction_nums)
+                    missing_fracs = sorted(expected_fracs - actual_fracs)
+
+                    if missing_fracs:
+                        all_basenames = set(os.path.basename(f) for f in raw_files)
+                        expected_names = {f for f in [f"{os.path.splitext(os.path.basename(f))[0].split('_f')[0]}_f{str(i).zfill(2)}.raw" for i in range(min_frac, max_frac + 1)]}
+                        missing_names = sorted(expected_names - all_basenames)
+
+                        print(
+                            f"\n🚨 Warning: Missing fraction files in {subfolder}.\n"
+                            f"Expected fractions from f{str(min_frac).zfill(2)} to f{str(max_frac).zfill(2)}.\n"
+                            f"Missing files:\n  " + "\n  ".join(missing_names) +
+                            "\nContinuing with available files.\n"
+                        )
+
                 fr_temp = pd.DataFrame({'Dataset': [os.path.basename(f) for f in raw_files]})
                 fr_temp['PlexID'] = f"S{sf}"
                 fr_list.append(fr_temp)
+        
             else:
                 raise ValueError(f"\n\nRaw files not found in this folder:\n{subfolder}")
 

--- a/scripts/create_study_design.py
+++ b/scripts/create_study_design.py
@@ -687,7 +687,7 @@ def main():
     logger.info("done")
 
     # Generate references.txt
-    logger.info("+ Generate references... ", end="")
+    logger.info("+ Generate references... ")
 
     # Conditional operation based on the presence of "Ref" samples
     if has_ref:
@@ -706,7 +706,7 @@ def main():
     logger.info("done")
 
     # Generate fractions.txt
-    logger.info("+ Generate fractions.txt file ", end="")
+    logger.info("+ Generate fractions.txt file")
 
     if raw_source == "manifest":
         fractions = process_manifest(raw_folder)

--- a/scripts/create_study_design.py
+++ b/scripts/create_study_design.py
@@ -594,12 +594,12 @@ def main():
         # Look for "RAW*" folder under batch_blob_prefix
         raw_folders = list_gcs_files(bucket_name, batch_blob_prefix, suffix="")
         raw_folder_paths = [
-            re.search(r"(.*RAW[^/]+)/\d{2}MOTRPAC_", blob).group(1)
+            re.search(r"(.*RAW[^/]*)/\d{2}MOTRPAC_", blob).group(1)
             for blob in raw_folders
-            if re.search(r"(.*RAW[^/]+)/\d{2}MOTRPAC_", blob)
+            if re.search(r"(.*RAW[^/]*)/\d{2}MOTRPAC_", blob)
         ]
         if not raw_folder_paths:
-            raise ValueError("Could not detect top-level RAW folder.")
+            raise ValueError("Could not detect RAW folder.")
 
         raw_folder = sorted(set(raw_folder_paths))[0]
 

--- a/scripts/create_study_design.py
+++ b/scripts/create_study_design.py
@@ -1,146 +1,193 @@
 #!/usr/bin/env python3
 
-import os
-import sys
-import re
 import argparse
-import pandas as pd
-import numpy as np
-from datetime import datetime
 import glob
-import warnings
+import logging
+import os
+import re
+from datetime import datetime
 
-def validate_batch(input_results_folder):
-    """
-    Extract BATCH_YYYYMMDD folder from input folder path.
+import numpy as np
+import pandas as pd
 
-    Args:
-        input_results_folder (str): input_results_folder path
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.DEBUG)
 
-    Returns:
-        str: BATCH_YYYYMMDD folder name
 
-    Raises:
-        ValueError: If batch folder is not recognized
+def validate_batch(input_results_folder: str) -> str:
+    """Extract BATCH_YYYYMMDD folder from input folder path.
+
+    :param input_results_folder: input_results_folder path
+    :returns: BATCH_YYYYMMDD folder name
+    :raises: ValueError: If batch folder is not recognized
     """
     # Try different patterns to be more flexible
     # First try the original pattern
-    batch_match = re.search(r".*/?(BATCH\d{1,2}\_\d{8})", input_results_folder)
+    batch_match = re.search(r".*/?(BATCH\d{1,2}_\d{8})", input_results_folder)
 
     if not batch_match:
         # Try alternative pattern without requiring a path before BATCH
-        batch_match = re.search(r"(BATCH\d{1,2}\_\d{8})", input_results_folder)
+        batch_match = re.search(r"(BATCH\d{1,2}_\d{8})", input_results_folder)
 
     if not batch_match:
-        raise ValueError("`BATCH#_YYYYMMDD` folder is not recognized in the folder structure.")
-    else:
-        return batch_match.group(1)
+        msg = "`BATCH#_YYYYMMDD` folder is not recognized in the folder structure."
+        raise ValueError(msg)
+
+    return batch_match.group(1)
 
 
-def validate_phase(input_results_folder, return_phase=True):
-    """
-    Extract PHASE from input folder path.
+def validate_phase(
+    input_results_folder: str, *, return_phase: bool = True
+) -> str | None:
+    """Extract PHASE from input folder path.
 
-    Args:
-        input_results_folder (str): input_results_folder path
-        return_phase (bool): return the phase only if True (default)
-
-    Returns:
-        str: PHASE code
-
-    Raises:
-        ValueError: If phase is not found in the folder structure
+    :param input_results_folder: input_results_folder path
+    :param return_phase: return the phase only if True (default)
+    :returns: PHASE code
+    :raises: ValueError: If phase is not found in the folder structure
     """
     phase = re.search(
         r"(PASS1A-06|PASS1A-18|PASS1B-06|PASS1B-18|PASS1C-06|PASS1C-18|PASS1AC-06|HUMAN|HUMAN-PRECOVID|HUMAN-MAIN-TR(?:0[1-9]|1[0-5]))",
-        input_results_folder)
+        input_results_folder,
+    )
 
     if not phase:
-        raise ValueError(
-            "- (-) Project phase is not found in the folder structure. Please check the MoTrPAC control vocabulary guidelines")
-    else:
-        if return_phase:
-            return phase.group(1)
+        msg = (
+            "- (-) Project phase is not found in the folder structure. "
+            "Please check the MoTrPAC control vocabulary guidelines"
+        )
+        raise ValueError(msg)
+
+    if return_phase:
+        return phase.group(1)
+
+    return None
 
 
-def validate_assay(input_results_folder):
-    """
-    Extract ASSAY from input folder path.
+def validate_assay(input_results_folder: str) -> str:
+    """Extract ASSAY from input folder path.
 
-    Args:
-        input_results_folder (str): input_results_folder path
-
-    Returns:
-        str: ASSAY code
-
-    Raises:
-        ValueError: If assay is not found
+    :param input_results_folder: input_results_folder path
+    :returns: ASSAY code
+    :raises: ValueError: If assay is not found
     """
     assay = re.search(
         r"(?<=T\d{2}/)(IONPNEG|RPNEG|RPPOS|HILICPOS|LRPPOS|LRPNEG|3HIB|AA|AC_DUKE|ACOA|BAIBA|CER_DUKE|KA|NUC|OA|SPHM|OXYLIPNEG|ETAMIDPOS|AC_MAYO|AMINES|CER_MAYO|TCA|LAB_GLC|LAB_INS|PROT_PH|PROT_PR|PROT_AC|PROT_UB|PROT_OL|PROT_OX|LAB_CK|LAB_CRT|LAB_CONV)",
-        input_results_folder
+        input_results_folder,
     )
 
     if not assay:
-        raise ValueError("ASSAY not found in the folder structure")
-    else:
-        return assay.group(0)
+        msg = "ASSAY not found in the folder structure"
+        raise ValueError(msg)
+
+    return assay.group(0)
 
 
-def validate_tissue(input_results_folder):
-    """
-    Extract and validate TISSUE CODE from input folder path.
+def validate_tissue(input_results_folder: str) -> str:
+    """Extract and validate TISSUE CODE from input folder path.
 
-    Args:
-        input_results_folder (str): input_results_folder path
-
-    Returns:
-        str: Tissue code
-
-    Raises:
-        ValueError: If tissue code is not valid
+    :param input_results_folder: input_results_folder path
+    :returns: Tissue code
+    :raises: ValueError: If tissue code is not valid
     """
     # Define the list of valid tissue codes as in bic_animal_tissue_code$bic_tissue_code
     bic_tissue_codes = [
-        "T01", "T02", "T03", "T04", "T05", "T06", "T07", "T08", "T09", "T10",
-        "T11", "T12", "T13", "T14", "T15", "T16", "T17", "T18", "T19", "T20",
-        "T21", "T30", "T31", "T32", "T33", "T34", "T35", "T36", "T37", "T38",
-        "T39", "T40", "T41", "T42", "T43", "T44", "T45", "T46", "T47", "T48",
-        "T49", "T50", "T51", "T52", "T53", "T54", "T55", "T56", "T57", "T58",
-        "T59", "T60", "T61", "T62", "T63", "T64", "T65", "T66", "T67", "T68",
-        "T69", "T70", "T77", "T99"
+        "T01",
+        "T02",
+        "T03",
+        "T04",
+        "T05",
+        "T06",
+        "T07",
+        "T08",
+        "T09",
+        "T10",
+        "T11",
+        "T12",
+        "T13",
+        "T14",
+        "T15",
+        "T16",
+        "T17",
+        "T18",
+        "T19",
+        "T20",
+        "T21",
+        "T30",
+        "T31",
+        "T32",
+        "T33",
+        "T34",
+        "T35",
+        "T36",
+        "T37",
+        "T38",
+        "T39",
+        "T40",
+        "T41",
+        "T42",
+        "T43",
+        "T44",
+        "T45",
+        "T46",
+        "T47",
+        "T48",
+        "T49",
+        "T50",
+        "T51",
+        "T52",
+        "T53",
+        "T54",
+        "T55",
+        "T56",
+        "T57",
+        "T58",
+        "T59",
+        "T60",
+        "T61",
+        "T62",
+        "T63",
+        "T64",
+        "T65",
+        "T66",
+        "T67",
+        "T68",
+        "T69",
+        "T70",
+        "T77",
+        "T99",
     ]
 
     # Extract tissue code using regex similar to gsub in R
     match = re.search(r"(.*)(T[0-9]{2,3})(.*)", input_results_folder)
     if not match:
-        raise ValueError("Tissue code not found in the folder structure")
+        msg = "Tissue code not found in the folder structure"
+        raise ValueError(msg)
 
     tissue_code = match.group(2)
 
     if tissue_code not in bic_tissue_codes:
-        raise ValueError(
+        msg = (
             f"tissue_code: `{tissue_code}` is not valid. Must be one of the following codes "
-            f"(check data object `MotrpacBicQC::bic_animal_tissue_code`):\n- {', '.join(bic_tissue_codes)}"
+            f"(check data object `MotrpacBicQC::bic_animal_tissue_code`):\n- "
+            f"{', '.join(bic_tissue_codes)}",
         )
-    else:
-        return tissue_code
+        raise ValueError(msg)
+
+    return tissue_code
 
 
-def find_unique_tmt_channel(tempcol):
-    """
-    Find unique TMT channel name in a list based on a specified pattern.
+def find_unique_tmt_channel(tempcol: list[str] | np.ndarray | pd.Series) -> str:
+    """Find unique TMT channel name in a list based on a specified pattern.
 
-    Args:
-        tempcol: A list of potential TMT channel names.
-
-    Returns:
-        The matching TMT channel name if exactly one match is found.
+    :param tempcol: A list of potential TMT channel names.
+    :returns: The matching TMT channel name if exactly one match is found.
         Raises error if no matches or multiple matches are found.
     """
     # Check that input is a list/array-like
     if not isinstance(tempcol, (list, np.ndarray, pd.Series)):
-        raise ValueError("Input must be a list-like object.")
+        msg = "Input must be a list-like object."
+        raise TypeError(msg)
 
     # Regular expression to find matches
     pattern = r"^tmt(\d{2})?_channel$"
@@ -152,25 +199,28 @@ def find_unique_tmt_channel(tempcol):
     if len(matches) == 1:
         # Return the matching variable
         return matches[0]
-    elif len(matches) > 1:
-        raise ValueError("Error: More than one matching element found.")
-    else:
-        raise ValueError("Error: No matching elements found.")
+    if len(matches) > 1:
+        msg = "Error: More than one matching element found."
+        raise ValueError(msg)
+    msg = "Error: No matching elements found."
+    raise ValueError(msg)
 
 
-def check_tmt_channels(tmt_type, tmt_expected, temp, tmt_col, tmt_details):
-    """
-    Check TMT channel consistency and provide detailed comparison.
+def check_tmt_channels(
+    tmt_type: str,
+    tmt_expected: list[str],
+    temp: pd.DataFrame,
+    tmt_col: str,
+    tmt_details: str,
+) -> None:
+    """Check TMT channel consistency and provide detailed comparison.
 
-    Args:
-        tmt_type: Type of TMT experiment
-        tmt_expected: List of expected TMT channels
-        temp: DataFrame with TMT data
-        tmt_col: Column name containing TMT channels
-        tmt_details: Path to TMT details file for error reporting
-
-    Raises:
-        ValueError if channel mismatch is detected
+    :param tmt_type: Type of TMT experiment
+    :param tmt_expected: List of expected TMT channels
+    :param temp: DataFrame with TMT data
+    :param tmt_col: Column name containing TMT channels
+    :param tmt_details: Path to TMT details file for error reporting
+    :raises: ValueError if channel mismatch is detected
     """
     actual_channels = sorted(temp[tmt_col].tolist())
     expected_channels = sorted(tmt_expected)
@@ -198,43 +248,197 @@ def check_tmt_channels(tmt_type, tmt_expected, temp, tmt_col, tmt_details):
         raise ValueError(error_message)
 
 
-def fix_duplicates(meta):
+def fix_duplicates(meta: pd.DataFrame) -> pd.DataFrame:
     """Fix duplicated vial_labels by making them unique."""
-    if meta['vial_label'].duplicated().any():
-        warnings.warn("Duplicate vial_label ids found. Making unique ids.")
+    if meta["vial_label"].duplicated().any():
+        logger.warning("Duplicate vial_label ids found. Making unique ids.")
         # Equivalent to R's make.unique
         seen = {}
         unique_names = []
-        for name in meta['vial_label']:
+        for name in meta["vial_label"]:
             if name in seen:
                 seen[name] += 1
                 unique_names.append(f"{name}.{seen[name]}")
             else:
                 seen[name] = 0
                 unique_names.append(name)
-        meta['vial_label'] = unique_names
+        meta["vial_label"] = unique_names
     return meta
 
 
-def main():
-    # Set up command line argument parser
-    parser = argparse.ArgumentParser(description='Generate PlexedPiper study_design files')
-
-    parser.add_argument('-f', '--file_vial_metadata', type=str, default='generate',
-                        help='File <-vial_metadata.txt> or type <generate> if it does not exist')
-    parser.add_argument('-b', '--batch_folder', type=str, required=True,
-                        help='Full path to the BATCH folder (from the PHASE folder)')
-    parser.add_argument('-c', '--cas', type=str, required=True,
-                        help='CAS: BI or PN)')
-    parser.add_argument('-s', '--raw_source', type=str, default='folder',
-                        help='Source to get the raw files: `manifest` from manifest file or `folder` to list them from the bucket raw folders')
-    parser.add_argument('-t', '--tmt', type=str, required=True,
-                        help='One of the following options: tmt11, tmt16, tmt18')
-    parser.add_argument('-p', '--phase', type=str, required=True,
-                        help='MOTRPAC PHASE')
-
+def cli_args() -> argparse.Namespace:
+    """Set up command line argument parser."""
+    parser = argparse.ArgumentParser(
+        description="Generate PlexedPiper study_design files",
+    )
+    parser.add_argument(
+        "-f",
+        "--file_vial_metadata",
+        type=str,
+        default="generate",
+        help="File <-vial_metadata.txt> or type <generate> if it does not exist",
+    )
+    parser.add_argument(
+        "-b",
+        "--batch_folder",
+        type=str,
+        required=True,
+        help="Full path to the BATCH folder (from the PHASE folder)",
+    )
+    parser.add_argument("-c", "--cas", type=str, required=True, help="CAS: BI or PN)")
+    parser.add_argument(
+        "-s",
+        "--raw_source",
+        type=str,
+        default="folder",
+        help="Source to get the raw files: `manifest` from manifest file or `folder` to list them from the bucket raw folders",
+    )
+    parser.add_argument(
+        "-t",
+        "--tmt",
+        type=str,
+        required=True,
+        help="One of the following options: tmt11, tmt16, tmt18",
+    )
+    parser.add_argument("-p", "--phase", type=str, required=True, help="MOTRPAC PHASE")
     # Parse arguments
-    args = parser.parse_args()
+    return parser.parse_args()
+
+
+def process_manifest(raw_folder: str) -> pd.DataFrame:
+    """Get fractions from file manifest files."""
+    fractions = None
+    logger.info("(from processing manifest files):")
+    file_manifest = glob.glob(
+        os.path.join(raw_folder, "**/*metadata_file.txt"),
+        recursive=True,
+    )
+    file_manifest.extend(
+        glob.glob(
+            os.path.join(raw_folder, "**/*raw_metadata_file*"),
+            recursive=True,
+        ),
+    )
+    # Sort the file paths to ensure they are in the correct order
+    file_manifest.sort()
+    for i, manifest_file in enumerate(file_manifest, 1):
+        logger.info("\t%s. File: %s", i, os.path.basename(manifest_file))
+
+        manifest = pd.read_csv(manifest_file, sep="\t")
+
+        manifest = manifest[["file_name"]]
+        manifest = manifest.rename(columns={"file_name": "Dataset"})
+
+        manifest["PlexID"] = f"S{i}"
+
+        if fractions is None:
+            fractions = manifest
+        else:
+            fractions = pd.concat([fractions, manifest], ignore_index=True)
+
+    return fractions
+
+
+def process_folder(raw_folder: str) -> pd.DataFrame:
+    """Get fractions from raw files in the folder."""
+    logger.info("(from listing raw files in folder)")
+    # Check subfolders
+    raw_subfolders = [
+        f
+        for f in glob.glob(os.path.join(raw_folder, "**/"))
+        if re.search(r".*/\d{2}.*", f)
+    ]
+    raw_subfolders.sort()
+    if not raw_subfolders:
+        msg = "The number of subfolders with raw data is equal to 0, which might mean that this submission is not according to MoTrPAC guidelines"
+        raise ValueError(msg)
+    fr_list = []
+    for sf, subfolder in enumerate(raw_subfolders, 1):
+        raw_files = glob.glob(os.path.join(subfolder, "**/*.raw"), recursive=True)
+
+        # Check and exclude empty *raw files
+        non_empty_raw_files = []
+        empty_raw_files = []
+
+        for raw_file in raw_files:
+            try:
+                with open(raw_file, "rb") as f:  # binary mode just in case
+                    first_line = f.readline()
+                    if first_line.strip():  # non-empty
+                        non_empty_raw_files.append(raw_file)
+                    else:
+                        empty_raw_files.append(os.path.basename(raw_file))
+            except Exception as err:
+                logger.warning("⚠️ Could not read %s", raw_file, exc_info=err)
+                empty_raw_files.append(os.path.basename(raw_file))
+
+        if empty_raw_files:
+            logger.warning(
+                "🚨 Warning: The following raw files in %s appears to be empty: %s\n"
+                "Please inspect for issues. Analysis will continue with non-empty files.\n",
+                subfolder,
+                "\n".join(empty_raw_files),
+            )
+
+        # Use only non-empty files going forward
+        raw_files = non_empty_raw_files
+
+        if raw_files:
+            invalid_files = [
+                f
+                for f in raw_files
+                if not re.search(r"_f\d{2,3}\.raw$", os.path.basename(f))
+            ]
+            if invalid_files:
+                msg = f"The following raw files do not follow the format of proposed file name: {'\n'.join(invalid_files)}. \n\nPlease check the MoTrPAC control vocabulary guidelines.\n"
+                raise ValueError(msg)
+
+            # Extract fraction numbers from filenames
+            fraction_nums = []
+            for f in raw_files:
+                match = re.search(r"_f(\d{2,3})\.raw$", os.path.basename(f))
+                if match:
+                    fraction_nums.append(int(match.group(1)))
+
+            if fraction_nums:
+                min_frac = min(fraction_nums)
+                max_frac = max(fraction_nums)
+                expected_fracs = set(range(min_frac, max_frac + 1))
+                actual_fracs = set(fraction_nums)
+                missing_fracs = sorted(expected_fracs - actual_fracs)
+
+                if missing_fracs:
+                    all_basenames = {os.path.basename(f) for f in raw_files}
+                    expected_names = {
+                        f"{os.path.splitext(os.path.basename(f))[0].split('_f')[0]}_f{str(i).zfill(2)}.raw"
+                        for i in range(min_frac, max_frac + 1)
+                    }
+                    missing_names = sorted(expected_names - all_basenames)
+
+                    logger.warning(
+                        "🚨 Warning: Missing fraction files in %s. Expected fractions from f%s to f%s."
+                        "Missing files:\n %s \nContinuing with available files.\n",
+                        subfolder,
+                        str(min_frac).zfill(2),
+                        str(max_frac).zfill(2),
+                        "\n ".join(missing_names),
+                    )
+
+            fr_temp = pd.DataFrame(
+                {"Dataset": [os.path.basename(f) for f in raw_files]},
+            )
+            fr_temp["PlexID"] = f"S{sf}"
+            fr_list.append(fr_temp)
+
+        else:
+            msg = f"Raw files not found in this folder: {subfolder}"
+            raise ValueError(msg)
+
+    return pd.concat(fr_list, ignore_index=True)
+
+
+def main():
+    args = cli_args()
 
     # Extract arguments for easier access
     file_vial_metadata = args.file_vial_metadata
@@ -245,23 +449,26 @@ def main():
     phase = args.phase
 
     # Debug information
-    print("\n# GENERATE PlexedPiper study_design FILES")
-    print(f"-f: Vial metadata: {file_vial_metadata}")
-    print(f"-c: Bach folder: {batch_folder}")
-    print(f"-u: Get the raw files from: {raw_source}")
-    print(f"-t: tmt experiment: {tmt}")
-    print("-------------------------------------")
+    logger.debug("\n# GENERATE PlexedPiper study_design FILES")
+    logger.debug("-f: Vial metadata: %s", file_vial_metadata)
+    logger.debug("-c: Bach folder: %s", batch_folder)
+    logger.debug("-u: Get the raw files from: %s", raw_source)
+    logger.debug("-t: tmt experiment: %s", tmt)
+    logger.debug("-------------------------------------")
 
     # Collect and Generate metadata
-    batch = validate_batch(batch_folder)
-    phase_folder = validate_phase(batch_folder)  # Placeholder for actual implementation
+    _batch = validate_batch(batch_folder)
+    _phase_folder = validate_phase(
+        batch_folder
+    )  # Placeholder for actual implementation
     assay = validate_assay(batch_folder)  # Placeholder for actual implementation
     assay = re.sub(r"(PROT_)(.*)", r"\2", assay)
     tissue = validate_tissue(batch_folder)  # Placeholder for actual implementation
 
     valid_cas = ["PN", "BI", "PNBI"]
     if cas not in valid_cas:
-        raise ValueError(f"<cas> must be one of this: {','.join(valid_cas)}")
+        msg = f"<cas> must be one of this: {','.join(valid_cas)}"
+        raise ValueError(msg)
 
     date = datetime.now().strftime("%Y%m%d")
 
@@ -271,27 +478,76 @@ def main():
     # Get RAW files folder name
     raw_folders = glob.glob(os.path.join(batch_folder, "RAW*"))
 
-    if not raw_folders:
-        # if There is no raw folder, then use BATCH folder
-        raw_folder = batch_folder
-    else:
-        raw_folder = raw_folders[0]
+    # if There is no raw folder, then use BATCH folder
+    raw_folder = batch_folder if not raw_folders else raw_folders[0]
 
     # Details about the tmt experiment
     if tmt == "tmt11":
         ecolnames = ["tmt_plex", "tmt11_channel", "vial_label"]
-        tmt11 = ["126C", "127N", "127C", "128N", "128C", "129N", "129C", "130N", "130C", "131N", "131C"]
+        tmt_channels = [
+            "126C",
+            "127N",
+            "127C",
+            "128N",
+            "128C",
+            "129N",
+            "129C",
+            "130N",
+            "130C",
+            "131N",
+            "131C",
+        ]
     elif tmt == "tmt16":
         ecolnames = ["tmt_plex", "tmt16_channel", "vial_label"]
-        tmt16 = ["126C", "127N", "127C", "128N", "128C", "129N", "129C", "130N", "130C", "131N", "131C", "132N", "132C", "133N", "133C", "134N"]
+        tmt_channels = [
+            "126C",
+            "127N",
+            "127C",
+            "128N",
+            "128C",
+            "129N",
+            "129C",
+            "130N",
+            "130C",
+            "131N",
+            "131C",
+            "132N",
+            "132C",
+            "133N",
+            "133C",
+            "134N",
+        ]
     elif tmt == "tmt18":
         ecolnames = ["tmt_plex", "tmt18_channel", "vial_label"]
-        tmt18 = ["126C", "127N", "127C", "128N", "128C", "129N", "129C", "130N", "130C", "131N", "131C", "132N", "132C", "133N", "133C", "134N", "134C", "135N"]
+        tmt_channels = [
+            "126C",
+            "127N",
+            "127C",
+            "128N",
+            "128C",
+            "129N",
+            "129C",
+            "130N",
+            "130C",
+            "131N",
+            "131C",
+            "132N",
+            "132C",
+            "133N",
+            "133C",
+            "134N",
+            "134C",
+            "135N",
+        ]
     else:
-        raise ValueError("<tmt> must be one of this: tmt11, tmt16, tmt18")
+        msg = "<tmt> must be one of this: tmt11, tmt16, tmt18"
+        raise ValueError(msg)
 
     # List all details.txt files recursively from the raw_folder
-    tmt_details_files = glob.glob(os.path.join(raw_folder, "**/*details.txt"), recursive=True)
+    tmt_details_files = glob.glob(
+        os.path.join(raw_folder, "**/*details.txt"),
+        recursive=True,
+    )
 
     # Sort the file paths to ensure they are in the correct order
     tmt_details_files.sort()
@@ -300,268 +556,194 @@ def main():
     nm_list = []
 
     if file_vial_metadata == "generate":
-        print("+ Generate vial metadata file")
+        logger.info("+ Generate vial metadata file")
 
         # Process each file
         for i, tmt_details in enumerate(tmt_details_files, 1):
             try:
-                temp = pd.read_csv(tmt_details, sep='\t')
-            except pd.errors.EmptyDataError:
-                raise ValueError(f"ERROR: '{tmt_details}' is empty. Please validate file integrity.")
+                temp = pd.read_csv(tmt_details, sep="\t")
+            except pd.errors.EmptyDataError as err:
+                msg = f"'{tmt_details}' is empty. Please validate file integrity."
+                raise ValueError(msg) from err
 
             if temp.empty or temp.shape[1] == 0:
-                raise ValueError(f"ERROR: '{tmt_details}' contains no data. Please validate file integrity.")
+                msg = (
+                    f"'{tmt_details}' contains no data. Please validate file integrity."
+                )
+                raise ValueError(msg)
 
             tmt_col = find_unique_tmt_channel(temp.columns.tolist())
 
             # Check TMT channels based on tmt type
-            if tmt == "tmt11":
-                check_tmt_channels(tmt, tmt11, temp, tmt_col, tmt_details)
-            elif tmt == "tmt16":
-                check_tmt_channels(tmt, tmt16, temp, tmt_col, tmt_details)
-            elif tmt == "tmt18":
-                check_tmt_channels(tmt, tmt18, temp, tmt_col, tmt_details)
+            check_tmt_channels(tmt, tmt_channels, temp, tmt_col, tmt_details)
 
             # Add custom labels
-            temp['tmt_plex'] = f"S{i}"
-            temp['vial_label'] = temp['vial_label'].apply(lambda x: f"Ref_S{i}" if "Ref" in str(x) else x)
+            temp["tmt_plex"] = f"S{i}"
+            temp["vial_label"] = temp["vial_label"].apply(
+                lambda x: f"Ref_S{i}" if "Ref" in str(x) else x,
+            )
 
             nm_list.append(temp)
 
         vial_metadata = pd.concat(nm_list, ignore_index=True)
-        file_vial_metadata = f"MOTRPAC_{phase}_{tissue}_{assay}_{cas}_{date}_vial_metadata.txt"
+        file_vial_metadata = (
+            f"MOTRPAC_{phase}_{tissue}_{assay}_{cas}_{date}_vial_metadata.txt"
+        )
 
     else:
-        print("+ Reading file vial metadata")
+        logger.info("+ Reading file vial metadata")
         try:
-            vial_metadata = pd.read_csv(file_vial_metadata, sep='\t')
+            vial_metadata = pd.read_csv(file_vial_metadata, sep="\t")
             if vial_metadata.empty:
-                raise ValueError(f"{file_vial_metadata} is empty. Please use generate option to generate vial metadata file.")
-        except pd.errors.EmptyDataError:
-            raise ValueError(f"{file_vial_metadata} is empty. Please use generate option to generate vial metadata file.")
-        
-        file_vial_metadata = f"MOTRPAC_{phase}_{tissue}_{assay}_{cas}_{date}_vial_metadata.txt"
+                msg = f"{file_vial_metadata} is empty. Please use generate option to generate vial metadata file."
+                raise ValueError(msg)
+        except pd.errors.EmptyDataError as err:
+            msg = f"{file_vial_metadata} is empty. Please use generate option to generate vial metadata file."
+            raise ValueError(msg) from err
 
-    print(f"\t - File name: {file_vial_metadata}")
+        file_vial_metadata = (
+            f"MOTRPAC_{phase}_{tissue}_{assay}_{cas}_{date}_vial_metadata.txt"
+        )
+
+    logger.info("File name: %s", file_vial_metadata)
 
     # Make adjustments: make sure that the Reference channel is "Ref_S#"
     vial_metadata.columns = vial_metadata.columns.str.lower()
-    vial_metadata['vial_label'] = vial_metadata.apply(
-        lambda row: f"Ref_{row['tmt_plex']}" if re.match(r"^ref", str(row['vial_label']), re.IGNORECASE) else row[
-            'vial_label'],
-        axis=1
+    vial_metadata["vial_label"] = vial_metadata.apply(
+        lambda row: f"Ref_{row['tmt_plex']}"
+        if re.match(r"^ref", str(row["vial_label"]), re.IGNORECASE)
+        else row["vial_label"],
+        axis=1,
     )
 
     # Check if there are any "Ref" samples
-    has_ref = any(vial_metadata['vial_label'].str.contains(r"^Ref", case=False, regex=True))
+    has_ref = any(
+        vial_metadata["vial_label"].str.contains(r"^Ref", case=False, regex=True),
+    )
 
     if not all(col in vial_metadata.columns for col in ecolnames):
         missing = [col for col in ecolnames if col not in vial_metadata.columns]
-        raise ValueError(f"Vial Metadata. The expected column names...\n\t{', '.join(ecolnames)}\n"
-                         f"are not available in vial_metadata: \n\t{', '.join(vial_metadata.columns)}\n"
-                         f"Missing columns: {', '.join(missing)}")
+        msg = (
+            f"Vial Metadata. The expected column names...\n\t{', '.join(ecolnames)}\n"
+            f"are not available in vial_metadata: \n\t{', '.join(vial_metadata.columns)}\n"
+            f"Missing columns: {', '.join(missing)}",
+        )
+        raise ValueError(msg)
 
     # Remove white spaces (known issue for pnnl submissions)
-    vial_metadata['vial_label'] = vial_metadata['vial_label'].str.replace(" ", "")
+    vial_metadata["vial_label"] = vial_metadata["vial_label"].str.replace(" ", "")
 
     # Fix duplicated vial_labels
     vial_metadata = fix_duplicates(meta=vial_metadata)
 
     # Generate samples.txt
-    print("+ Generate samples.txt... ", end="")
+    logger.info("+ Generate samples.txt... ")
 
     if tmt == "tmt11":
         samples = vial_metadata.copy()
-        samples['PlexID'] = samples['tmt_plex']
-        samples['QuantBlock'] = 1
-        samples['ReporterName'] = samples['tmt11_channel']
-        samples['ReporterAlias'] = samples['vial_label']
-        samples['MeasurementName'] = samples['vial_label']
-        samples = samples.drop(['tmt_plex', 'tmt11_channel', 'vial_label'], axis=1)
+        samples["PlexID"] = samples["tmt_plex"]
+        samples["QuantBlock"] = 1
+        samples["ReporterName"] = samples["tmt11_channel"]
+        samples["ReporterAlias"] = samples["vial_label"]
+        samples["MeasurementName"] = samples["vial_label"]
+        samples = samples.drop(["tmt_plex", "tmt11_channel", "vial_label"], axis=1)
     elif tmt == "tmt16":
         samples = vial_metadata.copy()
-        samples['PlexID'] = samples['tmt_plex']
-        samples['QuantBlock'] = 1
-        samples['ReporterName'] = samples['tmt16_channel']
-        samples['ReporterAlias'] = samples['vial_label']
-        samples['MeasurementName'] = samples['vial_label']
-        samples = samples.drop(['tmt_plex', 'tmt16_channel', 'vial_label'], axis=1)
+        samples["PlexID"] = samples["tmt_plex"]
+        samples["QuantBlock"] = 1
+        samples["ReporterName"] = samples["tmt16_channel"]
+        samples["ReporterAlias"] = samples["vial_label"]
+        samples["MeasurementName"] = samples["vial_label"]
+        samples = samples.drop(["tmt_plex", "tmt16_channel", "vial_label"], axis=1)
     elif tmt == "tmt18":
         samples = vial_metadata.copy()
-        samples['PlexID'] = samples['tmt_plex']
-        samples['QuantBlock'] = 1
-        samples['ReporterName'] = samples['tmt18_channel']
-        samples['ReporterAlias'] = samples['vial_label']
-        samples['MeasurementName'] = samples['vial_label']
-        samples = samples.drop(['tmt_plex', 'tmt18_channel', 'vial_label'], axis=1)
+        samples["PlexID"] = samples["tmt_plex"]
+        samples["QuantBlock"] = 1
+        samples["ReporterName"] = samples["tmt18_channel"]
+        samples["ReporterAlias"] = samples["vial_label"]
+        samples["MeasurementName"] = samples["vial_label"]
+        samples = samples.drop(["tmt_plex", "tmt18_channel", "vial_label"], axis=1)
+    else:
+        msg = "<tmt> must be one of this: tmt11, tmt16, tmt18"
+        raise ValueError(msg)
 
     # adjustments
-    samples['ReporterName'] = samples['ReporterName'].str.replace("126C", "126")
+    samples["ReporterName"] = samples["ReporterName"].str.replace("126C", "126")
 
     if has_ref:
-        samples['MeasurementName'] = samples['ReporterAlias']
-        ref_mask = samples['ReporterAlias'].str.contains(r"^ref", case=False, regex=True)
-        samples.loc[ref_mask, 'MeasurementName'] = None
+        samples["MeasurementName"] = samples["ReporterAlias"]
+        ref_mask = samples["ReporterAlias"].str.contains(
+            r"^ref",
+            case=False,
+            regex=True,
+        )
+        samples.loc[ref_mask, "MeasurementName"] = None
 
     # Select only required columns
-    samples = samples[["PlexID", "QuantBlock", "ReporterName", "ReporterAlias", "MeasurementName"]]
+    samples = samples[
+        ["PlexID", "QuantBlock", "ReporterName", "ReporterAlias", "MeasurementName"]
+    ]
 
-    print("done")
+    logger.info("done")
 
     # Generate references.txt
-    print("+ Generate references... ", end="")
+    logger.info("+ Generate references... ", end="")
 
     # Conditional operation based on the presence of "Ref" samples
     if has_ref:
-        references = samples[samples['ReporterAlias'].str.contains(r"^\+?Ref", regex=True)].copy()
-        references = references.drop(['ReporterName', 'MeasurementName'], axis=1)
-        references = references.rename(columns={'ReporterAlias': 'Reference'})
+        references = samples[
+            samples["ReporterAlias"].str.contains(r"^\+?Ref", regex=True)
+        ].copy()
+        references = references.drop(["ReporterName", "MeasurementName"], axis=1)
+        references = references.rename(columns={"ReporterAlias": "Reference"})
     else:
-        print("(no references available: value 1 would be added instead) ", end="")
-        references = samples[['PlexID', 'QuantBlock']].copy()
-        references['Reference'] = 1
+        logger.warning(
+            "(no references available: value 1 would be added instead) ", end=""
+        )
+        references = samples[["PlexID", "QuantBlock"]].copy()
+        references["Reference"] = 1
 
-    print("done")
+    logger.info("done")
 
     # Generate fractions.txt
-    print("+ Generate fractions.txt file ", end="")
-    fractions = None
+    logger.info("+ Generate fractions.txt file ", end="")
 
     if raw_source == "manifest":
-        print("(from processing manifest files):")
-        file_manifest = glob.glob(os.path.join(raw_folder, "**/*metadata_file.txt"), recursive=True)
-        file_manifest.extend(glob.glob(os.path.join(raw_folder, "**/*raw_metadata_file*"), recursive=True))
-
-        # Sort the file paths to ensure they are in the correct order
-        file_manifest.sort()
-
-        for i, manifest_file in enumerate(file_manifest, 1):
-            print(f"\t{i}. File: {os.path.basename(manifest_file)}")
-
-            manifest = pd.read_csv(manifest_file, sep='\t')
-
-            manifest = manifest[['file_name']]
-            manifest = manifest.rename(columns={'file_name': 'Dataset'})
-
-            manifest['PlexID'] = f"S{i}"
-
-            if fractions is None:
-                fractions = manifest
-            else:
-                fractions = pd.concat([fractions, manifest], ignore_index=True)
+        fractions = process_manifest(raw_folder)
 
     elif raw_source == "folder":
-        print("(from listing raw files in folder)")
-
-        # Check subfolders
-        raw_subfolders = [f for f in glob.glob(os.path.join(raw_folder, "**/")) if re.search(r".*/\d{2}.*", f)]
-        raw_subfolders.sort()
-
-        if not raw_subfolders:
-            raise ValueError(
-                "The number of subfolders with raw data is equal to 0, which might mean that this submission is not according to MoTrPAC guidelines")
-
-        fr_list = []
-        for sf, subfolder in enumerate(raw_subfolders, 1):
-            raw_files = glob.glob(os.path.join(subfolder, "**/*.raw"), recursive=True)
-
-            # Check and exclude empty *raw files
-            non_empty_raw_files = []
-            empty_raw_files = []
-
-            for raw_file in raw_files:
-                try:
-                    with open(raw_file, "rb") as f:  # binary mode just in case
-                        first_line = f.readline()
-                        if first_line.strip():  # non-empty
-                            non_empty_raw_files.append(raw_file)
-                        else:
-                            empty_raw_files.append(os.path.basename(raw_file))
-                except Exception as e:
-                    print(f"⚠️ Could not read {raw_file}: {e}")
-                    empty_raw_files.append(os.path.basename(raw_file))
-
-            if empty_raw_files:
-                print(
-                    f"\n🚨 Warning: The following raw files in {subfolder} appears to be empty:\n "
-                    + " \n    ".join(empty_raw_files)
-                    + "\n  Please inspect for issues. Analysis will continue with non-empty files.\n"
-                )
-
-            # Use only non-empty files going forward
-            raw_files = non_empty_raw_files
-
-            if raw_files:
-                invalid_files = [f for f in raw_files if not re.search(r"_f\d{2,3}\.raw$", os.path.basename(f))]
-                if invalid_files:
-                    raise ValueError(
-                        f"\nThe following raw files do not follow the format of proposed file name:\n" +
-                        "\n".join(invalid_files) +
-                        "\n\nPlease check the MoTrPAC control vocabulary guidelines.\n"
-                    )
-                
-                # Extract fraction numbers from filenames
-                fraction_nums = []
-                for f in raw_files:
-                    match = re.search(r"_f(\d{2,3})\.raw$", os.path.basename(f))
-                    if match:
-                        fraction_nums.append(int(match.group(1)))
-
-                if fraction_nums:
-                    min_frac = min(fraction_nums)
-                    max_frac = max(fraction_nums)
-                    expected_fracs = set(range(min_frac, max_frac + 1))
-                    actual_fracs = set(fraction_nums)
-                    missing_fracs = sorted(expected_fracs - actual_fracs)
-
-                    if missing_fracs:
-                        all_basenames = set(os.path.basename(f) for f in raw_files)
-                        expected_names = {f for f in [f"{os.path.splitext(os.path.basename(f))[0].split('_f')[0]}_f{str(i).zfill(2)}.raw" for i in range(min_frac, max_frac + 1)]}
-                        missing_names = sorted(expected_names - all_basenames)
-
-                        print(
-                            f"\n🚨 Warning: Missing fraction files in {subfolder}.\n"
-                            f"Expected fractions from f{str(min_frac).zfill(2)} to f{str(max_frac).zfill(2)}.\n"
-                            f"Missing files:\n  " + "\n  ".join(missing_names) +
-                            "\nContinuing with available files.\n"
-                        )
-
-                fr_temp = pd.DataFrame({'Dataset': [os.path.basename(f) for f in raw_files]})
-                fr_temp['PlexID'] = f"S{sf}"
-                fr_list.append(fr_temp)
-        
-            else:
-                raise ValueError(f"\n\nRaw files not found in this folder:\n{subfolder}")
-
-        fractions = pd.concat(fr_list, ignore_index=True)
-
+        fractions = process_folder(raw_folder)
     else:
-        raise ValueError("The -s argument is not right. It should be either `manifest` or `folder`")
+        msg = "The -s argument is not right. It should be either `manifest` or `folder`"
+        raise ValueError(msg)
 
-    fractions['Dataset'] = fractions['Dataset'].str.replace(".raw", "")
+    fractions["Dataset"] = fractions["Dataset"].str.replace(".raw", "")
 
-    print("+ Checking PlexID notations")
+    logger.info("+ Checking PlexID notations")
     # Extract unique and sorted values from each data frame's relevant variable
-    unique_fractions = sorted(fractions['PlexID'].unique())
-    unique_samples = sorted(samples['PlexID'].unique())
-    unique_references = sorted(references['PlexID'].unique())
-    unique_vial_metadata = sorted(vial_metadata['tmt_plex'].unique())
+    unique_fractions = sorted(fractions["PlexID"].unique())
+    unique_samples = sorted(samples["PlexID"].unique())
+    unique_references = sorted(references["PlexID"].unique())
+    unique_vial_metadata = sorted(vial_metadata["tmt_plex"].unique())
 
     # Compare all vectors for equality
-    are_equal = (unique_fractions == unique_samples and
-                 unique_samples == unique_references and
-                 unique_references == unique_vial_metadata)
+    are_equal = (
+        unique_fractions == unique_samples
+        and unique_samples == unique_references
+        and unique_references == unique_vial_metadata
+    )
 
     # Output the result
     if are_equal:
-        print("+ Validations: All PlexID lists are identical.")
+        logger.info("+ Validations: All PlexID lists are identical.")
     else:
-        print("Not all PlexID lists are identical. Detailed comparison needed.")
-        print(f"Fractions PlexID: {','.join(unique_fractions)}")
-        print(f"Samples PlexID: {','.join(unique_samples)}")
-        print(f"References PlexID: {','.join(unique_references)}")
-        print(f"Vial Metadata tmt_plex: {','.join(unique_vial_metadata)}")
-        raise ValueError("Fix PlexID before printing out files")
+        logger.error("Not all PlexID lists are identical. Detailed comparison needed.")
+        logger.error("Fractions PlexID: %s", ",".join(unique_fractions))
+        logger.error("Samples PlexID: %s", ",".join(unique_samples))
+        logger.error("References PlexID: %s", ",".join(unique_references))
+        logger.error("Vial Metadata tmt_plex: %s", ",".join(unique_vial_metadata))
+        msg = "Fix PlexID before printing out files"
+        raise ValueError(msg)
 
     # Print out files
     # The study_design folder should be in the RAW folder, but given that in
@@ -572,19 +754,21 @@ def main():
     if not os.path.exists(output_viallabel_name):
         os.makedirs(output_viallabel_name, exist_ok=True)
 
-    fractions.to_csv(os.path.join(output_viallabel_name, "fractions.txt"),
-                     sep='\t', index=False)
+    fractions_path = os.path.join(os.path.join(output_viallabel_name, "fractions.txt"))
+    fractions.to_csv(fractions_path, sep="\t", index=False)
 
-    references.to_csv(os.path.join(output_viallabel_name, "references.txt"),
-                      sep='\t', index=False)
+    references_path = os.path.join(
+        os.path.join(output_viallabel_name, "references.txt"),
+    )
+    references.to_csv(references_path, sep="\t", index=False)
 
-    samples.to_csv(os.path.join(output_viallabel_name, "samples.txt"),
-                   sep='\t', index=False)
+    samples_path = os.path.join(output_viallabel_name, "samples.txt")
+    samples.to_csv(samples_path, sep="\t", index=False)
 
-    vial_metadata.to_csv(os.path.join(output_viallabel_name, file_vial_metadata),
-                         sep='\t', index=False)
+    vial_metadata_path = os.path.join(output_viallabel_name, file_vial_metadata)
+    vial_metadata.to_csv(vial_metadata_path, sep="\t", index=False)
 
-    print(f"\nAll files are out! Check them out at:\n{output_viallabel_name}")
+    logger.info("All files are out! Check them out at: %s", output_viallabel_name)
 
 
 if __name__ == "__main__":

--- a/scripts/create_study_design.py
+++ b/scripts/create_study_design.py
@@ -11,7 +11,7 @@ import numpy as np
 import pandas as pd
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(message)s")
 
 
 def validate_batch(input_results_folder: str) -> str:

--- a/scripts/generate_file_manifest.py
+++ b/scripts/generate_file_manifest.py
@@ -1,97 +1,1023 @@
+#!/usr/bin/env python3
+"""Generate PlexedPiper study_design files for MoTrPAC proteomics data.
+
+This script creates the four study_design files required by PlexedPiper
+(fractions.txt, samples.txt, references.txt, and vial_metadata) from
+raw proteomics data stored locally or in a Google Cloud Storage bucket.
+
+It validates folder structure, TMT channel assignments, and raw file naming
+conventions against MoTrPAC controlled vocabulary guidelines.
+
+Usage:
+    python generate_file_manifest.py -b <batch_folder> -c <cas> -t <tmt> -p <phase>
+        [-f <vial_metadata>] [-s <raw_source>] [-o <output_dir>]
+"""
+
 import argparse
-import sys
-from base64 import b64decode
-from typing import Iterator, Tuple
+import glob
+import logging
+import os
+import re
+from datetime import datetime
+import numpy as np
+import pandas as pd
+from google.cloud import storage
+from io import StringIO
+import warnings
+import http.client
 
+# Disable low-level HTTP debug logs
+http.client.HTTPConnection.debuglevel = 0
 
-try:
-    from google.cloud import storage
-    from google.cloud.storage import Blob, Bucket
-except ImportError:
-    print("Please install google-cloud-storage", file=sys.stderr)
-    sys.exit(1)
+# Silence Google's warnings and logs
+# Set up your script-level logger
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
-if sys.version_info[0] < 3:
-    raise Exception("Must be using at least Python 3.9")
-if sys.version_info[1] < 9:
-    raise Exception("Must be using at least Python 3.9")
+# Basic config (don't use DEBUG level here unless needed)
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(message)s"
+)
 
-SEPARATOR = ","
-storage_client = storage.Client()
+# Silence noisy loggers
+for lib in [
+    "google.auth",
+    "google.auth.transport",
+    "google.auth.transport.requests",
+    "google.api_core",
+    "google.cloud",
+    "google.cloud.storage",
+    "google.resumable_media",
+    "urllib3",
+    "urllib3.connectionpool",
+]:
+    logging.getLogger(lib).setLevel(logging.WARNING)
 
+# Suppress specific UserWarnings
+warnings.filterwarnings("ignore", category=UserWarning, module="google.auth")
 
-def parse_bucket_path(path: str) -> Tuple[str, str]:
+# === GCS Support === #
+def is_gcs_path(input_results_folder: str) -> bool:
+    """Check if provided path is a GCS path."""
+    return input_results_folder.startswith("gs://")
+
+def parse_gcs_path(gcs_path: str) -> tuple[str, str]:
+    """Parse gs://bucket_name/path/to/folder into bucket_name and blob prefix."""
+    if not is_gcs_path(gcs_path):
+        raise ValueError("Not a valid GCS path with prefix 'gs://'")
+    
+    path = gcs_path.replace("gs://", "")
+    parts = path.split("/", 1)
+    bucket_name = parts[0]
+    blob_path = parts[1] if len(parts) > 1 else ""
+
+    return bucket_name, blob_path.rstrip("/")
+
+def list_gcs_files(bucket_name: str, prefix: str, suffix: str = "") -> list[str]:
+    """List blob names in a GCS bucket filtered by prefix and optional suffix.
+
+    :param bucket_name: Name of the GCS bucket.
+    :param prefix: Blob name prefix to filter on.
+    :param suffix: Only return blobs whose names end with this string.
+    :returns: List of matching blob name strings.
     """
-    Split a full S3 path in bucket and key strings. 's3://bucket/key' -> ('bucket', 'key')
-    :param path: S3 path (e.g. s3://bucket/key).
-    :return: Tuple of bucket and key strings
+    gcs_client = storage.Client()
+    bucket = gcs_client.bucket(bucket_name)
+    return [
+        blob.name
+        for blob in bucket.list_blobs(prefix=prefix)
+        if blob.name.endswith(suffix)
+    ]
+
+def read_gcs_tsv(bucket_name: str, blob_name: str, sep="\t") -> pd.DataFrame:
+    """Read a delimited file from GCS into a pandas DataFrame.
+
+    :param bucket_name: Name of the GCS bucket.
+    :param blob_name: Full blob path within the bucket.
+    :param sep: Column delimiter (default: tab).
+    :returns: DataFrame with the file contents.
     """
-    if path.startswith("gs://") is False:
-        raise ValueError(f"'{path}' is not a valid path. It MUST start with 'gs://'")
+    gcs_client = storage.Client()
+    bucket = gcs_client.bucket(bucket_name)
+    blob = bucket.blob(blob_name)
+    content = blob.download_as_text()
+    return pd.read_csv(StringIO(content), sep=sep)
 
-    # remove the gs:// prefix, then split on the first "/" character
-    parts = path.replace("gs://", "").split("/", 1)
-    # the bucket is the first split part
-    bucket: str = parts[0]
-    if bucket == "":
-        raise ValueError("Empty bucket name received")
-    if "/" in bucket or bucket == " ":
-        raise ValueError(f"'{bucket}' is not a valid bucket name.")
-    # the key is the second split part
-    key: str = ""
-    if len(parts) == 2:
-        key = key if parts[1] is None else parts[1]
+# === Validation Functions === #
+def validate_batch(input_results_folder: str) -> str:
+    """Extract BATCH_YYYYMMDD folder from input folder path.
 
-    return bucket.rstrip("/"), f"{key.rstrip('/')}/"
+    :param input_results_folder: input_results_folder path
+    :returns: BATCH_YYYYMMDD folder name
+    :raises: ValueError: If batch folder is not recognized
+    """
+    # Try different patterns to be more flexible
+    # First try the original pattern
+    batch_match = re.search(r".*/?(BATCH\d{1,2}_\d{8})", input_results_folder)
+
+    if not batch_match:
+        # Try alternative pattern without requiring a path before BATCH
+        batch_match = re.search(r"(BATCH\d{1,2}_\d{8})", input_results_folder)
+
+    if not batch_match:
+        msg = "`BATCH#_YYYYMMDD` folder is not recognized in the folder structure."
+        raise ValueError(msg)
+
+    return batch_match.group(1)
 
 
-def generate_manifest(path, outfile):
-    lines = 0
-    data = "file_name,md5\n"
+def validate_phase(input_results_folder: str, *, return_phase: bool = True) -> str | None:
+    """Extract PHASE from input folder path.
 
-    bucket_name, prefix = parse_bucket_path(path)
+    :param input_results_folder: input_results_folder path
+    :param return_phase: return the phase only if True (default)
+    :returns: PHASE code
+    :raises: ValueError: If phase is not found in the folder structure
+    """
+    phase = re.search(
+        r"(PASS1A-06|PASS1A-18|PASS1B-06|PASS1B-18|PASS1C-06|PASS1C-18|PASS1AC-06|HUMAN|HUMAN-PRECOVID|HUMAN-MAIN-TR(?:0[1-9]|1[0-5]))",
+        input_results_folder,
+    )
 
-    bucket: Bucket = storage_client.bucket(bucket_name)
-    blob_list: Iterator[Blob] = bucket.list_blobs(prefix=prefix)
+    if not phase:
+        msg = (
+            "- (-) Project phase is not found in the folder structure. "
+            "Please check the MoTrPAC control vocabulary guidelines"
+        )
+        raise ValueError(msg)
 
-    for blob in blob_list:
-        print(f"Processing {blob.name}")
-        if blob.name.endswith("/") or "file_manifest" in blob.name:
-            continue
-        relative_filename = blob.name.removeprefix(prefix)
-        decoded_hash = b64decode(blob.md5_hash).hex()
-        data += f"{relative_filename},{decoded_hash}\n"
-        lines += 1
+    if return_phase:
+        return phase.group(1)
 
-    manifest_name = f"{prefix}{outfile}"
+    return None
 
-    print(f"Writing manifest to {manifest_name}")
-    print(data)
 
-    file_manifest_blob = Blob(bucket=bucket, name=manifest_name)
-    file_manifest_blob.upload_from_string(data, content_type="text/csv")
+def validate_assay(input_results_folder: str) -> str:
+    """Extract ASSAY from input folder path.
 
-    if lines == 0:
-        raise Exception(f"No files found at {path}. Please double check")
+    :param input_results_folder: input_results_folder path
+    :returns: ASSAY code
+    :raises: ValueError: If assay is not found
+    """
+    assay = re.search(
+        r"(?<=T\d{2}/)(IONPNEG|RPNEG|RPPOS|HILICPOS|LRPPOS|LRPNEG|3HIB|AA|AC_DUKE|ACOA|BAIBA|CER_DUKE|KA|NUC|OA|SPHM|OXYLIPNEG|ETAMIDPOS|AC_MAYO|AMINES|CER_MAYO|TCA|LAB_GLC|LAB_INS|PROT_PH|PROT_PR|PROT_AC|PROT_UB|PROT_OL|PROT_OX|LAB_CK|LAB_CRT|LAB_CONV)",
+        input_results_folder,
+    )
+
+    if not assay:
+        msg = "ASSAY not found in the folder structure"
+        raise ValueError(msg)
+
+    return assay.group(0)
+
+
+def validate_tissue(input_results_folder: str) -> str:
+    """Extract and validate TISSUE CODE from input folder path.
+
+    :param input_results_folder: input_results_folder path
+    :returns: Tissue code
+    :raises: ValueError: If tissue code is not valid
+    """
+    # Define the list of valid tissue codes as in bic_animal_tissue_code$bic_tissue_code
+    bic_tissue_codes = ["T01", "T02", "T03", "T04", "T05", "T06", "T07", "T08", "T09", 
+                        "T10", "T11", "T12", "T13", "T14", "T15", "T16", "T17", "T18", "T19", 
+                        "T20", "T21",
+                        "T30", "T31", "T32",  "T33", "T34", "T35", "T36", "T37", "T38", "T39",
+                        "T40", "T41", "T42", "T43", "T44", "T45", "T46", "T47", "T48", "T49",
+                        "T50", "T51", "T52", "T53", "T54", "T55", "T56", "T57", "T58", "T59",
+                        "T60", "T61", "T62", "T63", "T64", "T65", "T66", "T67", "T68", "T69",
+                        "T70", "T77",
+                        "T99"]
+
+    # Extract tissue code using regex similar to gsub in R
+    match = re.search(r"(.*)(T[0-9]{2,3})(.*)", input_results_folder)
+    if not match:
+        msg = "Tissue code not found in the folder structure"
+        raise ValueError(msg)
+
+    tissue_code = match.group(2)
+
+    if tissue_code not in bic_tissue_codes:
+        msg = (
+            f"tissue_code: `{tissue_code}` is not valid. Must be one of the following codes "
+            f"(check data object `MotrpacBicQC::bic_animal_tissue_code`):\n- "
+            f"{', '.join(bic_tissue_codes)}",
+        )
+        raise ValueError(msg)
+
+    return tissue_code
+
+
+def find_unique_tmt_channel(tempcol: list[str] | np.ndarray | pd.Series) -> str:
+    """Find unique TMT channel name in a list based on a specified pattern.
+
+    :param tempcol: A list of potential TMT channel names.
+    :returns: The matching TMT channel name if exactly one match is found.
+        Raises error if no matches or multiple matches are found.
+    """
+    # Check that input is a list/array-like
+    if not isinstance(tempcol, (list, np.ndarray, pd.Series)):
+        msg = "Input must be a list-like object."
+        raise TypeError(msg)
+
+    # Regular expression to find matches
+    pattern = r"^tmt(\d{2})?_channel$"
+
+    # Find matches
+    matches = [col for col in tempcol if re.match(pattern, col)]
+
+    # Check the number of matches
+    if len(matches) == 1:
+        # Return the matching variable
+        return matches[0]
+    if len(matches) > 1:
+        msg = "Error: More than one matching element found."
+        raise ValueError(msg)
+    msg = "Error: No matching elements found."
+    raise ValueError(msg)
+
+
+def check_tmt_channels(tmt_type: str, tmt_expected: list[str], temp: pd.DataFrame, tmt_col: str, tmt_details: str) -> None:
+    """Check TMT channel consistency and provide detailed comparison.
+
+    :param tmt_type: Type of TMT experiment
+    :param tmt_expected: List of expected TMT channels
+    :param temp: DataFrame with TMT data
+    :param tmt_col: Column name containing TMT channels
+    :param tmt_details: Path to TMT details file for error reporting
+    :raises: ValueError if channel mismatch is detected
+    """
+    actual_channels = sorted(temp[tmt_col].tolist())
+    expected_channels = sorted(tmt_expected)
+
+    if expected_channels != actual_channels:
+        # Find differences and intersections
+        shared_channels = set(expected_channels).intersection(set(actual_channels))
+        missed_in_actual = set(expected_channels).difference(set(actual_channels))
+        extra_in_actual = set(actual_channels).difference(set(expected_channels))
+
+        # Build error message
+        error_message = (
+            f"Something is wrong: the expected `{tmt_type}` channels and the `{tmt_type}` "
+            f"channels available in the `{os.path.basename(tmt_details)}` file do not match."
+            f"\nThis likely means that there is a mismatch between the tmt specified as argument and the actual channels available in the data files.\n"
+        )
+
+        if shared_channels:
+            error_message += f"\nShared channels: {', '.join(shared_channels)}"
+        if missed_in_actual:
+            error_message += f"\nMissing in actual data: {', '.join(missed_in_actual)}"
+        if extra_in_actual:
+            error_message += f"\nExtra in actual data: {', '.join(extra_in_actual)}"
+
+        raise ValueError(error_message)
+
+
+def fix_duplicates(meta: pd.DataFrame) -> pd.DataFrame:
+    """Fix duplicated vial_labels by making them unique."""
+    if meta["vial_label"].duplicated().any():
+        dup_labels = meta.loc[meta["vial_label"].duplicated(keep=False), "vial_label"].unique().tolist()
+        logger.warning(
+            "Duplicate vial_label(s) found: %s. Renaming to make unique (e.g. label.1, label.2).",
+            ", ".join(dup_labels)
+        )
+        # Equivalent to R's make.unique
+        seen = {}
+        unique_names = []
+        for name in meta["vial_label"]:
+            if name in seen:
+                seen[name] += 1
+                unique_names.append(f"{name}.{seen[name]}")
+            else:
+                seen[name] = 0
+                unique_names.append(name)
+        meta["vial_label"] = unique_names
+    return meta
+
+# === CLI Argument Parsing === #
+def cli_args() -> argparse.Namespace:
+    """Set up command line argument parser."""
+    parser = argparse.ArgumentParser(description="Generate PlexedPiper study_design files")
+    parser.add_argument(
+        "-f",
+        "--file_vial_metadata",
+        type=str,
+        default="generate",
+        help="File <-vial_metadata.txt> or type <generate> if it does not exist",
+    )
+    parser.add_argument(
+        "-b",
+        "--batch_folder",
+        type=str,
+        required=True,
+        help="Full path to the BATCH folder (from the PHASE folder)",
+    )
+    parser.add_argument("-c", "--cas", type=str, required=True, help="CAS: BI or PN)")
+    parser.add_argument(
+        "-s",
+        "--raw_source",
+        type=str,
+        default="folder",
+        help="Source to get the raw files: `manifest` from manifest file or `folder` to list them from the bucket raw folders",
+    )
+    parser.add_argument(
+        "-t",
+        "--tmt",
+        type=str,
+        required=True,
+        help="One of the following options: tmt11, tmt16, tmt18",
+    )
+    parser.add_argument("-p", "--phase", type=str, required=True, help="MOTRPAC PHASE")
+    
+    parser.add_argument(
+        "-o", "--output_dir", type=str,
+        help="Output directory for study_design files (REQUIRED if --batch_folder is a GCS path)"
+    )
+
+    args = parser.parse_args()
+
+    # Enforce output_dir if GCS is used
+    if is_gcs_path(args.batch_folder) and not args.output_dir:
+        parser.error("--output_dir is required when --batch_folder is a GCS path")
+
+    return args
+
+# === Main Processing Functions === #
+def process_manifest(raw_folder: str, is_gcs: bool = False, bucket_name: str = None) -> pd.DataFrame:
+    """Build a fractions DataFrame from file manifest metadata files.
+
+    Reads ``*metadata_file.txt`` and ``*raw_metadata_file`` files from either
+    a local directory or a GCS bucket, extracts the ``file_name`` column, and
+    assigns sequential PlexIDs (S1, S2, ...).
+
+    :param raw_folder: Path to the folder containing raw data (local or GCS).
+    :param is_gcs: Whether *raw_folder* is a GCS path (auto-detected internally).
+    :param bucket_name: GCS bucket name (unused; bucket is parsed from *raw_folder*).
+    :returns: DataFrame with columns ``Dataset`` and ``PlexID``.
+    :raises ValueError: If no manifest files are found.
+    """
+
+    is_gcs = is_gcs_path(raw_folder)
+    
+    # If the path is a GCS path, parse it
+    if is_gcs:
+        fractions = None
+        logger.info("(from processing manifest files in GCS bucket):")
+        bucket, prefix = parse_gcs_path(raw_folder)
+        # List relevant metadata files in GCS bucket
+        metadata_files = list_gcs_files(bucket, prefix, suffix="metadata_file.txt")
+        metadata_files += list_gcs_files(bucket, prefix, suffix="raw_metadata_file")
+
+        # Sort the GCS blob paths
+        metadata_files.sort()
+
+        for i, blob_name in enumerate(metadata_files, 1):
+            logger.info("\t%s. File: %s", i, os.path.basename(blob_name))
+
+            manifest = read_gcs_tsv(bucket, blob_name, sep="\t")
+            manifest = manifest[["file_name"]].rename(columns={"file_name": "Dataset"})
+            manifest["PlexID"] = f"S{i}"
+            
+            if fractions is None:
+                fractions = manifest
+            else:
+                fractions = pd.concat([fractions, manifest], ignore_index=True)
+
     else:
-        print(f"Wrote data for {lines} files")
+        # If the path is a local folder, process it as before
+        logger.info("(from processing manifest files in local folder):")
+        fractions = None
+
+        # List relevant metadata files in local folder
+        file_manifest = glob.glob(os.path.join(raw_folder, "**/*metadata_file.txt"), recursive=True)
+        file_manifest.extend(glob.glob(os.path.join(raw_folder, "**/*raw_metadata_file*"), recursive=True))
+
+        # Sort the file paths to ensure they are in the correct order
+        file_manifest.sort()
+
+        for i, manifest_file in enumerate(file_manifest, 1):
+            logger.info("\t%s. File: %s", i, os.path.basename(manifest_file))
+
+            manifest = pd.read_csv(manifest_file, sep="\t")
+
+            manifest = manifest[["file_name"]]
+            manifest = manifest.rename(columns={"file_name": "Dataset"})
+
+            manifest["PlexID"] = f"S{i}"
+            
+            if fractions is None:
+                fractions = manifest
+            else:
+                fractions = pd.concat([fractions, manifest], ignore_index=True)
+            
+    if not fractions:
+        raise ValueError("No manifest files found in the provided folder.")
+
+    return fractions
+
+def process_folder(raw_folder: str, is_gcs: bool = False, bucket_name: str = None) -> pd.DataFrame:
+    """Build a fractions DataFrame by listing ``.raw`` files in subfolders.
+
+    Scans subfolders (named with a leading two-digit number per MoTrPAC
+    convention) for ``.raw`` files. Validates file naming, checks for empty
+    files and missing fractions, and assigns sequential PlexIDs.
+
+    :param raw_folder: Path (local) or blob prefix (GCS) to the raw data folder.
+    :param is_gcs: Whether the path refers to a GCS location.
+    :param bucket_name: GCS bucket name (required when *is_gcs* is True).
+    :returns: DataFrame with columns ``Dataset`` and ``PlexID``.
+    :raises ValueError: If no subfolders or valid raw files are found.
+    """
+
+    # If the path is a GCS path, parse it
+    if is_gcs:
+        logger.info("(from listing raw files in GCS bucket)")
+        fr_list = []
+        if not bucket_name:
+            raise ValueError("Bucket name must be provided when using GCS.")
+        prefix = raw_folder
+        gcs_client = storage.Client()
+        bucket = gcs_client.bucket(bucket_name)
+
+        # Collect subdirectories under prefix (match MoTrPAC subfolder format)
+        raw_subfolders = set()
+        for blob in gcs_client.list_blobs(bucket_name, prefix=prefix):
+            match = re.search(r"(.*/\d{2}[^/]*)/.*\.raw$", blob.name)
+            if match:
+                raw_subfolders.add(match.group(1))
+        raw_subfolders = sorted(raw_subfolders)
+
+        if not raw_subfolders:
+            raise ValueError("The number of subfolders with raw data is equal to 0, which might mean that this submission is not according to MoTrPAC guidelinea. Check MoTrPAC submission structure.")
+        
+        for sf, subfolder_prefix in enumerate(raw_subfolders, 1):
+            blobs = list(bucket.list_blobs(prefix=subfolder_prefix))
+            raw_files = [blob for blob in blobs if blob.name.endswith(".raw")]
+
+            # Filter out empty files
+            non_empty_raw_files = []
+            empty_raw_files = []
+
+            for blob in raw_files:
+                if blob.size == 0:
+                    empty_raw_files.append(os.path.basename(blob.name))
+                else:
+                    non_empty_raw_files.append(blob)
+
+            if empty_raw_files:
+                logger.warning(
+                    "🚨 Warning: The following raw files in %s appears to be empty: %s\n"
+                    "Please inspect for issues. Analysis will continue with non-empty files.\n",
+                    subfolder_prefix,
+                    "\n".join(empty_raw_files),
+                )
+
+            if not non_empty_raw_files:
+                raise ValueError(f"No valid .raw files in GCS subfolder: {subfolder_prefix}")
+
+            # Validate filenames (accept *_f{nn}.raw, *_fr{nn}.raw, *_f{nn}_{x}.raw, *_fr{nn}_{x}.raw)
+            invalid_files = []
+            nonstandard_files = []
+
+            for blob in non_empty_raw_files:
+                filename = os.path.basename(blob.name)
+                if re.search(r"_f(r)?\d{2,3}\.raw$", filename):
+                    continue  # standard
+                elif re.search(r"_f(r)?\d{2,3}_.+\.raw$", filename):
+                    nonstandard_files.append(blob.name)  # accepted, but nonstandard
+                else:
+                    invalid_files.append(blob.name)  # invalid
+            
+            # Raise error if any file is truly invalid
+            if invalid_files:
+                msg = (
+                    f"The following raw files do not follow any accepted naming format:\n"
+                    f"{chr(10).join(invalid_files)}\n\n"
+                    f"Please check the MoTrPAC control vocabulary guidelines.\n"
+                )
+                raise ValueError(msg)
+
+            # Warn if nonstandard files are used
+            if nonstandard_files:
+                logger.warning(
+                    "⚠️ The following raw files use nonstandard naming (e.g. *_f{nn}_{x}.raw):\n%s\n"
+                    "These will be processed, but it's recommended to rename them to *_f{nn}.raw or *_fr{nn}.raw for future submissions.\n",
+                    "\n".join(nonstandard_files)
+                )
+
+            # Extract fraction numbers
+            fraction_nums = []
+            for blob in non_empty_raw_files:
+                filename = os.path.basename(blob.name)
+                match = re.search(r"_f(?:r)?(\d{2,3})(?:_.+)?\.raw$", filename)
+                if match:
+                    fraction_nums.append(int(match.group(1)))
+            
+            if fraction_nums:
+                min_frac = min(fraction_nums)
+                max_frac = max(fraction_nums)
+                expected_fracs = set(range(min_frac, max_frac + 1))
+                actual_fracs = set(fraction_nums)
+                missing_fracs = sorted(expected_fracs - actual_fracs)
+                    
+                if missing_fracs:
+                    all_basenames = {os.path.basename(b.name) for b in non_empty_raw_files}
+                    
+                    # Extract sample_prefix from first file (remove _f{nn} or _fr{nn} and optional _{timestamp})
+                    first_base = os.path.splitext(os.path.basename(non_empty_raw_files[0].name))[0]
+                    match = re.search(r"(.*)_f(r)?\d{2,3}(?:_.+)?$", first_base)
+                    sample_prefix = match.group(1) if match else first_base
+                    has_fr = "_fr" in os.path.basename(non_empty_raw_files[0].name)
+                    suffix = "fr" if has_fr else "f"
+
+                    # Build expected filenames (standard naming only)
+                    expected_names = {
+                        f"{sample_prefix}_{suffix}{str(i).zfill(2)}.raw"
+                        for i in range(min_frac, max_frac + 1)
+                    }
+
+                    # Compare against raw file basenames
+                    missing_names = sorted(expected_names - all_basenames)
+
+                    logger.warning(
+                        "🚨 Warning: Missing fractions in %s. Expected f%02d to f%02d.\nMissing files:\n%s",
+                        subfolder_prefix, min_frac, max_frac, "\n".join(missing_names)
+                    )
+
+            fr_temp = pd.DataFrame({
+                "Dataset": [os.path.basename(blob.name) for blob in non_empty_raw_files]
+            })
+            fr_temp["PlexID"] = f"S{sf}"
+            fr_list.append(fr_temp)
+        return pd.concat(fr_list, ignore_index=True)
+
+    else:
+        logger.info("(from listing raw files in local folder)")
+
+        raw_subfolders = [
+            f
+            for f in glob.glob(os.path.join(raw_folder, "**/"))
+            if re.search(r".*/\d{2}.*", f)
+        ]
+        raw_subfolders.sort()
+        if not raw_subfolders:
+            msg = "The number of subfolders with raw data is equal to 0, which might mean that this submission is not according to MoTrPAC guidelines"
+            raise ValueError(msg)
+        fr_list = []
+        for sf, subfolder in enumerate(raw_subfolders, 1):
+            raw_files = glob.glob(os.path.join(subfolder, "**/*.raw"), recursive=True)
+
+            # Check and exclude empty *raw files
+            non_empty_raw_files = []
+            empty_raw_files = []
+
+            for raw_file in raw_files:
+                try:
+                    with open(raw_file, "rb") as f:  # binary mode just in case
+                        first_line = f.readline()
+                        if first_line.strip():  # non-empty
+                            non_empty_raw_files.append(raw_file)
+                        else:
+                            empty_raw_files.append(os.path.basename(raw_file))
+                except Exception as err:
+                    logger.warning("⚠️ Could not read %s", raw_file, exc_info=err)
+                    empty_raw_files.append(os.path.basename(raw_file))
+
+            if empty_raw_files:
+                logger.warning(
+                    "🚨 Warning: The following raw files in %s appears to be empty: %s\n"
+                    "Please inspect for issues. Analysis will continue with non-empty files.\n",
+                    subfolder,
+                    "\n".join(empty_raw_files),
+                )
+
+            # Use only non-empty files going forward
+            raw_files = non_empty_raw_files
+
+            if raw_files:
+                invalid_files = []
+                nonstandard_files = []
+
+                for f in raw_files:
+                    filename = os.path.basename(f)
+                    if re.search(r"_f(r)?\d{2,3}\.raw$", filename):
+                        continue  # Standard
+                    elif re.search(r"_f(r)?\d{2,3}_.+\.raw$", filename):
+                        nonstandard_files.append(f)
+                    else:
+                        invalid_files.append(f)
+
+                if invalid_files:
+                    msg = (
+                        f"The following raw files do not follow any accepted naming format:\n"
+                        f"{chr(10).join(invalid_files)}\n\n"
+                        f"Please check the MoTrPAC control vocabulary guidelines.\n"
+                    )
+                    raise ValueError(msg)
+
+                if nonstandard_files:
+                    logger.warning(
+                        "⚠️ The following raw files use nonstandard naming (e.g. *_f{nn}_{x}.raw):\n%s\n"
+                        "These will be processed, but should be renamed to *_f{nn}.raw or *_fr{nn}.raw in future.\n",
+                        "\n".join(nonstandard_files)
+                    )
+
+                # Extract fraction numbers from filenames
+                fraction_nums = []
+                for f in raw_files:
+                    filename = os.path.basename(f)
+                    match = re.search(r"_f(?:r)?(\d{2,3})(?:_.+)?\.raw$", filename)
+                    if match:
+                        fraction_nums.append(int(match.group(1)))
+
+                if fraction_nums:
+                    min_frac = min(fraction_nums)
+                    max_frac = max(fraction_nums)
+                    expected_fracs = set(range(min_frac, max_frac + 1))
+                    actual_fracs = set(fraction_nums)
+                    missing_fracs = sorted(expected_fracs - actual_fracs)
+
+
+                    if missing_fracs:
+                        all_basenames = {os.path.basename(f) for f in raw_files}
+
+                        # Extract sample prefix, stripping suffix _fNN_{x} or _frNN_{x}
+                        first_base = os.path.splitext(os.path.basename(raw_files[0]))[0]
+                        match = re.search(r"(.*)_f(r)?\d{2,3}(?:_.+)?$", first_base)
+                        sample_prefix = match.group(1) if match else first_base
+                        has_fr = "_fr" in os.path.basename(raw_files[0])
+                        suffix = "fr" if has_fr else "f"
+
+                        # Expected names use only standard format
+                        expected_names = {
+                            f"{sample_prefix}_{suffix}{str(i).zfill(2)}.raw"
+                            for i in range(min_frac, max_frac + 1)
+                        }
+
+                        missing_names = sorted(expected_names - all_basenames)
+
+                        logger.warning(
+                            "🚨 Warning: Missing fraction files in %s. Expected fractions from f%s to f%s.\n"
+                            "Missing files:\n%s\nContinuing with available files.\n",
+                            subfolder,
+                            str(min_frac).zfill(2),
+                            str(max_frac).zfill(2),
+                            "\n".join(missing_names),
+                        )
+
+                # Construct dataframe of observed files
+                fr_temp = pd.DataFrame({
+                    "Dataset": [os.path.basename(f) for f in raw_files]
+                })
+                fr_temp["PlexID"] = f"S{sf}"
+                fr_list.append(fr_temp)
+            else:
+                msg = f"Raw files not found in this folder: {subfolder}"
+                raise ValueError(msg)
+
+        return pd.concat(fr_list, ignore_index=True)
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="Creates manifest for submission to BIC: a comma separated file "
-                    "with relative file paths and md5 sums."
+    """Entry point: parse CLI arguments and generate study_design files.
+
+    Orchestrates validation, vial metadata generation, and output of
+    fractions.txt, samples.txt, references.txt, and the vial metadata file.
+    """
+    args = cli_args()
+
+    # Extract arguments for easier access
+    file_vial_metadata = args.file_vial_metadata
+    batch_folder = args.batch_folder
+    cas = args.cas
+    raw_source = args.raw_source
+    tmt = args.tmt
+    phase = args.phase
+
+    # Debug information
+    logger.debug("\n# GENERATE PlexedPiper study_design FILES")
+    logger.debug("-f: Vial metadata: %s", file_vial_metadata)
+    logger.debug("-c: Batch folder: %s", batch_folder)
+    logger.debug("-u: Get the raw files from: %s", raw_source)
+    logger.debug("-t: tmt experiment: %s", tmt)
+    logger.debug("-------------------------------------")
+
+    # Collect and Generate metadata
+    _batch = validate_batch(batch_folder)
+    _phase_folder = validate_phase(batch_folder)  # Placeholder for actual implementation
+    assay = validate_assay(batch_folder)  # Placeholder for actual implementation
+    assay = re.sub(r"(PROT_)(.*)", r"\2", assay)
+    tissue = validate_tissue(batch_folder)  # Placeholder for actual implementation
+
+    valid_cas = ["PN", "BI", "PNBI"]
+    if cas not in valid_cas:
+        msg = f"<cas> must be one of this: {','.join(valid_cas)}"
+        raise ValueError(msg)
+
+    date = datetime.now().strftime("%Y%m%d")
+
+    # Process batch folder from either local folder or GCS bucket
+    is_gcs = is_gcs_path(batch_folder)
+    if is_gcs:
+        bucket_name, batch_blob_prefix = parse_gcs_path(batch_folder)
+    else:
+        batch_folder = os.path.abspath(batch_folder)
+
+    # Get RAW folder from GCS bucket
+    if is_gcs:
+        # Look for "RAW*" folder under batch_blob_prefix
+        raw_folders = list_gcs_files(bucket_name, batch_blob_prefix, suffix="")
+        raw_folder_paths = [
+            re.search(r"(.*RAW[^/]*)/\d{2}MOTRPAC_", blob).group(1)
+            for blob in raw_folders
+            if re.search(r"(.*RAW[^/]*)/\d{2}MOTRPAC_", blob)
+        ]
+        if not raw_folder_paths:
+            raise ValueError("Could not detect RAW folder.")
+
+        raw_folder = sorted(set(raw_folder_paths))[0]
+
+    else:
+        raw_folders = glob.glob(os.path.join(batch_folder, "RAW*"))
+        raw_folder = batch_folder if not raw_folders else raw_folders[0]
+
+    # Details about the tmt experiment
+    if tmt == "tmt11":
+        ecolnames = ["tmt_plex", "tmt11_channel", "vial_label"]
+        tmt_channels = ["126C", "127N", "127C", "128N", "128C", "129N", "129C", "130N", "130C", "131N", "131C"]
+    elif tmt == "tmt16":
+        ecolnames = ["tmt_plex", "tmt16_channel", "vial_label"]
+        tmt_channels = ["126C", "127N", "127C", "128N",  "128C", "129N", "129C", "130N", "130C", "131N", "131C",
+                        "132N", "132C", "133N", "133C", "134N"]
+    elif tmt == "tmt18":
+        ecolnames = ["tmt_plex", "tmt18_channel", "vial_label"]
+        tmt_channels = ["126C", "127N", "127C", "128N", "128C", "129N", "129C", "130N", "130C", "131N", "131C",
+                        "132N", "132C", "133N", "133C", "134N",
+                        "134C", "135N"]
+    else:
+        msg = "<tmt> must be one of this: tmt11, tmt16, tmt18"
+        raise ValueError(msg)
+
+    # List all details.txt files recursively from the raw_folder
+    if is_gcs:
+        tmt_details_files = list_gcs_files(bucket_name, raw_folder, suffix="details.txt")
+        tmt_details_files.sort()
+    else:
+        tmt_details_files = glob.glob(os.path.join(raw_folder, "**/*details.txt"), recursive=True)
+        tmt_details_files.sort()
+
+    # Initialize an empty list to store data
+    nm_list = []
+
+    if file_vial_metadata == "generate":
+        logger.info("+ Generating vial metadata from %d TMT details file(s)", len(tmt_details_files))
+
+        # Process each file
+        for i, tmt_details in enumerate(tmt_details_files, 1):
+            try:
+                if is_gcs:
+                    temp = read_gcs_tsv(bucket_name, tmt_details)
+                else:
+                    temp = pd.read_csv(tmt_details, sep="\t")
+
+            except pd.errors.EmptyDataError as err:
+                msg = f"'{tmt_details}' is empty. Please validate file integrity."
+                raise ValueError(msg) from err
+
+            if temp.empty or temp.shape[1] == 0:
+                msg = (
+                    f"'{tmt_details}' contains no data. Please validate file integrity."
+                )
+                raise ValueError(msg)
+
+            tmt_col = find_unique_tmt_channel(temp.columns.tolist())
+
+            # Check TMT channels based on tmt type
+            check_tmt_channels(tmt, tmt_channels, temp, tmt_col, tmt_details)
+
+            # Add custom labels
+            temp["tmt_plex"] = f"S{i}"
+            temp["vial_label"] = temp["vial_label"].apply(
+                lambda x: f"Ref_S{i}" if "Ref" in str(x) else x,
+            )
+
+            # Check for multiple Ref entries in a single TMTdetails file
+            num_ref = temp["vial_label"].str.startswith("Ref_S").sum()
+            if num_ref > 1:
+                raise ValueError(
+                    f"❌ '{tmt_details}' contains {num_ref} vial_label entries starting with 'Ref'.\n"
+                    f"Only one reference sample is allowed per TMTdetails file.\n"
+                    f"Please check the file: {tmt_details}"
+                )
+
+            nm_list.append(temp)
+
+        vial_metadata = pd.concat(nm_list, ignore_index=True)
+        n_plexes = vial_metadata["tmt_plex"].nunique()
+        n_samples = len(vial_metadata)
+        logger.info("  Vial metadata generated: %d samples across %d plex(es)", n_samples, n_plexes)
+        file_vial_metadata = (
+            f"MOTRPAC_{phase}_{tissue}_{assay}_{cas}_{date}_vial_metadata.txt"
+        )
+
+    else:
+        logger.info("+ Reading vial metadata from file: %s", file_vial_metadata)
+        try:
+            if is_gcs:
+                vial_metadata = read_gcs_tsv(bucket_name, file_vial_metadata)
+            else:
+                vial_metadata = pd.read_csv(file_vial_metadata, sep="\t")
+            if vial_metadata.empty:
+                msg = f"{file_vial_metadata} is empty. Please use generate option to generate vial metadata file."
+                raise ValueError(msg)
+        except pd.errors.EmptyDataError as err:
+            msg = f"{file_vial_metadata} is empty. Please use generate option to generate vial metadata file."
+            raise ValueError(msg) from err
+
+        file_vial_metadata = (
+            f"MOTRPAC_{phase}_{tissue}_{assay}_{cas}_{date}_vial_metadata.txt"
+        )
+
+    logger.info("  Output vial metadata file: %s", file_vial_metadata)
+
+    # Make adjustments: make sure that the Reference channel is "Ref_S#"
+    vial_metadata.columns = vial_metadata.columns.str.lower()
+    vial_metadata["vial_label"] = vial_metadata.apply(
+        lambda row: f"Ref_{row['tmt_plex']}"
+        if re.match(r"^ref", str(row["vial_label"]), re.IGNORECASE)
+        else row["vial_label"],
+        axis=1,
     )
-    parser.add_argument(
-        "data_path",
-        help="Full path to folder containing all files for data submission "
-             "(including gs:// prefix)",
+
+    # Check if there are any "Ref" samples
+    has_ref = any(
+        vial_metadata["vial_label"].str.contains(r"^Ref", case=False, regex=True),
     )
-    parser.add_argument(
-        "output", default="file_manifest.csv", help="Name of the output file"
+
+    if not all(col in vial_metadata.columns for col in ecolnames):
+        missing = [col for col in ecolnames if col not in vial_metadata.columns]
+        msg = (
+            f"Vial Metadata. The expected column names...\n\t{', '.join(ecolnames)}\n"
+            f"are not available in vial_metadata: \n\t{', '.join(vial_metadata.columns)}\n"
+            f"Missing columns: {', '.join(missing)}",
+        )
+        raise ValueError(msg)
+
+    # Remove white spaces (known issue for pnnl submissions)
+    vial_metadata["vial_label"] = vial_metadata["vial_label"].str.replace(" ", "")
+
+    # Fix duplicated vial_labels
+    vial_metadata = fix_duplicates(meta=vial_metadata)
+
+    # Generate samples.txt
+    logger.info("+ Generating samples.txt")
+
+    if tmt == "tmt11":
+        samples = vial_metadata.copy()
+        samples["PlexID"] = samples["tmt_plex"]
+        samples["QuantBlock"] = 1
+        samples["ReporterName"] = samples["tmt11_channel"]
+        samples["ReporterAlias"] = samples["vial_label"]
+        samples["MeasurementName"] = samples["vial_label"]
+        samples = samples.drop(["tmt_plex", "tmt11_channel", "vial_label"], axis=1)
+    elif tmt == "tmt16":
+        samples = vial_metadata.copy()
+        samples["PlexID"] = samples["tmt_plex"]
+        samples["QuantBlock"] = 1
+        samples["ReporterName"] = samples["tmt16_channel"]
+        samples["ReporterAlias"] = samples["vial_label"]
+        samples["MeasurementName"] = samples["vial_label"]
+        samples = samples.drop(["tmt_plex", "tmt16_channel", "vial_label"], axis=1)
+    elif tmt == "tmt18":
+        samples = vial_metadata.copy()
+        samples["PlexID"] = samples["tmt_plex"]
+        samples["QuantBlock"] = 1
+        samples["ReporterName"] = samples["tmt18_channel"]
+        samples["ReporterAlias"] = samples["vial_label"]
+        samples["MeasurementName"] = samples["vial_label"]
+        samples = samples.drop(["tmt_plex", "tmt18_channel", "vial_label"], axis=1)
+    else:
+        msg = "<tmt> must be one of this: tmt11, tmt16, tmt18"
+        raise ValueError(msg)
+
+    # adjustments
+    samples["ReporterName"] = samples["ReporterName"].str.replace("126C", "126")
+
+    if has_ref:
+        samples["MeasurementName"] = samples["ReporterAlias"]
+        # Matches values in the "ReporterAlias" column that starts with "Ref" or "ref" (case-insensitive)
+        ref_mask = samples["ReporterAlias"].str.contains(r"^ref", case=False, regex=True)
+        samples.loc[ref_mask, "MeasurementName"] = "NA"
+
+    # Select only required columns
+    samples = samples[
+        ["PlexID", "QuantBlock", "ReporterName", "ReporterAlias", "MeasurementName"]
+    ]
+
+    n_measurement = samples["MeasurementName"].ne("NA").sum()
+    logger.info("  samples.txt: %d rows (%d measurements, %d plexes)",
+                len(samples), n_measurement, samples["PlexID"].nunique())
+
+    # Generate references.txt
+    logger.info("+ Generating references.txt")
+
+    # Conditional operation based on the presence of "Ref" samples
+    if has_ref:
+        references = samples[
+            samples["ReporterAlias"].str.contains(r"^\+?Ref", regex=True)
+        ].copy()
+        references = references.drop(["ReporterName", "MeasurementName"], axis=1)
+        references = references.rename(columns={"ReporterAlias": "Reference"})
+    else:
+        logger.warning(
+            "No reference channels found in vial metadata. Using QuantBlock=1 as reference placeholder."
+        )
+        references = samples[["PlexID", "QuantBlock"]].copy()
+        references["Reference"] = 1
+
+    logger.info("  references.txt: %d reference(s) across %d plex(es)",
+                len(references), references["PlexID"].nunique())
+
+    # Generate fractions.txt
+    logger.info("+ Generating fractions.txt")
+
+    if raw_source == "manifest":
+        fractions = process_manifest(raw_folder)
+
+    elif raw_source == "folder":
+        fractions = process_folder(raw_folder, is_gcs=is_gcs, bucket_name=bucket_name if is_gcs else None)
+
+    else:
+        msg = "The -s argument is not right. It should be either `manifest` or `folder`"
+        raise ValueError(msg)
+    
+    fractions["Dataset"] = fractions["Dataset"].str.replace(".raw", "")
+
+    logger.info("  fractions.txt: %d datasets across %d plex(es)",
+                len(fractions), fractions["PlexID"].nunique())
+
+    logger.info("+ Cross-validating PlexIDs across all study_design tables")
+    # Extract unique and sorted values from each data frame's relevant variable
+    unique_fractions = sorted(fractions["PlexID"].unique())
+    unique_samples = sorted(samples["PlexID"].unique())
+    unique_references = sorted(references["PlexID"].unique())
+    unique_vial_metadata = sorted(vial_metadata["tmt_plex"].unique())
+
+    # Compare all vectors for equality
+    are_equal = (
+        unique_fractions == unique_samples
+        and unique_samples == unique_references
+        and unique_references == unique_vial_metadata
     )
-    args = parser.parse_args()
-    generate_manifest(args.data_path, args.output)
+
+    # Output the result
+    if are_equal:
+        logger.info("  PlexIDs match across fractions, samples, references, and vial_metadata: %s",
+                    ", ".join(unique_fractions))
+    else:
+        logger.error("PlexID mismatch detected across study_design tables:")
+        logger.error("Fractions PlexID: %s", ",".join(unique_fractions))
+        logger.error("Samples PlexID: %s", ",".join(unique_samples))
+        logger.error("References PlexID: %s", ",".join(unique_references))
+        logger.error("Vial Metadata tmt_plex: %s", ",".join(unique_vial_metadata))
+        msg = "Fix PlexID before printing out files"
+        raise ValueError(msg)
+
+    # Print out files
+    # The study_design folder should be in the RAW folder, but given that in
+    # some cases the RAW files were not given in the RAW folder, it might be
+    # located in the BATCH folder.
+    if is_gcs:
+        output_viallabel_name = os.path.join(args.output_dir, "study_design")
+    else:
+        output_viallabel_name = os.path.join(raw_folder, "study_design")
+
+    if not os.path.exists(output_viallabel_name):
+        os.makedirs(output_viallabel_name, exist_ok=True)
+
+    fractions_path = os.path.join(os.path.join(output_viallabel_name, "fractions.txt"))
+    fractions.to_csv(fractions_path, sep="\t", index=False)
+
+    references_path = os.path.join(
+        os.path.join(output_viallabel_name, "references.txt"),
+    )
+    references.to_csv(references_path, sep="\t", index=False)
+
+    samples_path = os.path.join(output_viallabel_name, "samples.txt")
+    samples.to_csv(samples_path, sep="\t", index=False)
+
+    vial_metadata_path = os.path.join(output_viallabel_name, file_vial_metadata)
+    vial_metadata.to_csv(vial_metadata_path, sep="\t", index=False)
+
+    logger.info("")
+    logger.info("=" * 50)
+    logger.info("  Study design files written to: %s", output_viallabel_name)
+    logger.info("  - fractions.txt   (%d rows)", len(fractions))
+    logger.info("  - samples.txt     (%d rows)", len(samples))
+    logger.info("  - references.txt  (%d rows)", len(references))
+    logger.info("  - %s", file_vial_metadata)
+    logger.info("=" * 50)
 
 
 if __name__ == "__main__":

--- a/scripts/generate_file_manifest.py
+++ b/scripts/generate_file_manifest.py
@@ -104,6 +104,19 @@ def read_gcs_tsv(bucket_name: str, blob_name: str, sep="\t") -> pd.DataFrame:
     content = blob.download_as_text()
     return pd.read_csv(StringIO(content), sep=sep)
 
+def write_gcs_tsv(bucket_name: str, blob_name: str, df: pd.DataFrame, sep: str = "\t") -> None:
+    """Write a pandas DataFrame as a delimited file to GCS.
+
+    :param bucket_name: Name of the GCS bucket.
+    :param blob_name: Full blob path within the bucket.
+    :param df: DataFrame to write.
+    :param sep: Column delimiter (default: tab).
+    """
+    gcs_client = storage.Client()
+    bucket = gcs_client.bucket(bucket_name)
+    blob = bucket.blob(blob_name)
+    blob.upload_from_string(df.to_csv(sep=sep, index=False), content_type="text/plain")
+
 # === Validation Functions === #
 def validate_batch(input_results_folder: str) -> str:
     """Extract BATCH_YYYYMMDD folder from input folder path.
@@ -332,14 +345,11 @@ def cli_args() -> argparse.Namespace:
     
     parser.add_argument(
         "-o", "--output_dir", type=str,
-        help="Output directory for study_design files (REQUIRED if --batch_folder is a GCS path)"
+        help="Output directory for study_design files (local path or gs:// path). "
+             "Defaults to the RAW folder in the bucket when --batch_folder is a GCS path."
     )
 
     args = parser.parse_args()
-
-    # Enforce output_dir if GCS is used
-    if is_gcs_path(args.batch_folder) and not args.output_dir:
-        parser.error("--output_dir is required when --batch_folder is a GCS path")
 
     return args
 
@@ -695,6 +705,13 @@ def main():
     tmt = args.tmt
     phase = args.phase
 
+    # Warn user about GCS output when no --output_dir is provided
+    if is_gcs_path(batch_folder) and not args.output_dir:
+        logger.info(
+            "No --output_dir specified. Study design files will be written directly "
+            "to the GCS bucket (RAW/study_design/). Use -o <local_path> to write locally instead."
+        )
+
     # Debug information
     logger.debug("\n# GENERATE PlexedPiper study_design FILES")
     logger.debug("-f: Vial metadata: %s", file_vial_metadata)
@@ -988,27 +1005,46 @@ def main():
     # The study_design folder should be in the RAW folder, but given that in
     # some cases the RAW files were not given in the RAW folder, it might be
     # located in the BATCH folder.
+    output_dir = args.output_dir
+
     if is_gcs:
-        output_viallabel_name = os.path.join(args.output_dir, "study_design")
+        if output_dir and is_gcs_path(output_dir):
+            # User explicitly provided a GCS output path
+            gcs_output_bucket, gcs_output_prefix = parse_gcs_path(output_dir)
+            gcs_output_prefix = f"{gcs_output_prefix}study_design/"
+            write_to_gcs = True
+        elif output_dir:
+            # User provided a local output path
+            write_to_gcs = False
+        else:
+            # Default: write to RAW/study_design/ in the same bucket
+            gcs_output_bucket = bucket_name
+            gcs_output_prefix = f"{raw_folder}/study_design/"
+            write_to_gcs = True
     else:
-        output_viallabel_name = os.path.join(raw_folder, "study_design")
+        write_to_gcs = False
 
-    if not os.path.exists(output_viallabel_name):
-        os.makedirs(output_viallabel_name, exist_ok=True)
+    if write_to_gcs:
+        output_viallabel_name = f"gs://{gcs_output_bucket}/{gcs_output_prefix}"
+        logger.info("+ Writing study_design files to GCS: %s", output_viallabel_name)
 
-    fractions_path = os.path.join(os.path.join(output_viallabel_name, "fractions.txt"))
-    fractions.to_csv(fractions_path, sep="\t", index=False)
+        write_gcs_tsv(gcs_output_bucket, f"{gcs_output_prefix}fractions.txt", fractions)
+        write_gcs_tsv(gcs_output_bucket, f"{gcs_output_prefix}references.txt", references)
+        write_gcs_tsv(gcs_output_bucket, f"{gcs_output_prefix}samples.txt", samples)
+        write_gcs_tsv(gcs_output_bucket, f"{gcs_output_prefix}{file_vial_metadata}", vial_metadata)
+    else:
+        if output_dir:
+            output_viallabel_name = os.path.join(output_dir, "study_design")
+        else:
+            output_viallabel_name = os.path.join(raw_folder, "study_design")
 
-    references_path = os.path.join(
-        os.path.join(output_viallabel_name, "references.txt"),
-    )
-    references.to_csv(references_path, sep="\t", index=False)
+        if not os.path.exists(output_viallabel_name):
+            os.makedirs(output_viallabel_name, exist_ok=True)
 
-    samples_path = os.path.join(output_viallabel_name, "samples.txt")
-    samples.to_csv(samples_path, sep="\t", index=False)
-
-    vial_metadata_path = os.path.join(output_viallabel_name, file_vial_metadata)
-    vial_metadata.to_csv(vial_metadata_path, sep="\t", index=False)
+        fractions.to_csv(os.path.join(output_viallabel_name, "fractions.txt"), sep="\t", index=False)
+        references.to_csv(os.path.join(output_viallabel_name, "references.txt"), sep="\t", index=False)
+        samples.to_csv(os.path.join(output_viallabel_name, "samples.txt"), sep="\t", index=False)
+        vial_metadata.to_csv(os.path.join(output_viallabel_name, file_vial_metadata), sep="\t", index=False)
 
     logger.info("")
     logger.info("=" * 50)

--- a/wdl/proteomics_maxquant.wdl
+++ b/wdl/proteomics_maxquant.wdl
@@ -25,6 +25,7 @@ workflow proteomics_maxquant {
         Int mq_ramGB
         Int? mq_disk
         String mq_docker
+        Int num_preemptible_attempts = 2
     }
 
     call maxquant {
@@ -35,7 +36,8 @@ workflow proteomics_maxquant {
             disks = mq_disk,
             mq_parameters = mq_parameters,
             fasta_sequence_db = fasta_sequence_db,
-            raw_file = raw_file
+            raw_file = raw_file,
+            preemptible = num_preemptible_attempts
     }
 }
 
@@ -45,6 +47,7 @@ task maxquant {
         Int ramGB
         Int? disks
         String docker
+        Int preemptible
         File mq_parameters
         File fasta_sequence_db
         Array[File] raw_file
@@ -97,10 +100,11 @@ task maxquant {
     }
 
     runtime {
-        docker: "${docker}"
+        cpu: ncpu
         memory: "${ramGB} GB"
-        cpu: "${ncpu}"
         disks: "local-disk ${select_first([disks, 100])} HDD"
+        docker: "${docker}"
+        preemptible: preemptible
     }
     
     parameter_meta {

--- a/wdl/proteomics_msgfplus.wdl
+++ b/wdl/proteomics_msgfplus.wdl
@@ -53,7 +53,10 @@ workflow proteomics_msgfplus {
         }
     }
 
-    input {    # Quantification method
+    input {
+        Int num_preemptible_attempts = 2
+
+        # Quantification method
         String quant_method
 
         # RAW INPUT FILES
@@ -66,7 +69,6 @@ workflow proteomics_msgfplus {
         Int masic_ramGB
         String masic_docker
         Int? masic_disk
-        Int masic_preemptible = 2
         File masic_parameter
 
         # MSCONVERT
@@ -74,14 +76,12 @@ workflow proteomics_msgfplus {
         Int msconvert_ramGB
         String msconvert_docker
         Int? msconvert_disk
-        Int msconvert_preemptible = 2
 
         # MS-GF+ SHARED OPTIONS
         Int msgf_ncpu
         Int msgf_ramGB
         String msgf_docker
         Int? msgf_disk
-        Int msgf_preemptible = 2
         File fasta_sequence_db
         String sequence_db_name
 
@@ -102,7 +102,6 @@ workflow proteomics_msgfplus {
         Int phrp_ramGB
         String phrp_docker
         Int? phrp_disk
-        Int phrp_preemptible = 2
 
         File phrp_parameter_m
         File phrp_parameter_t
@@ -116,7 +115,6 @@ workflow proteomics_msgfplus {
         Int? ascore_ramGB
         String? ascore_docker
         Int? ascore_disk
-        Int? ascore_preemptible = 2
         File? ascore_parameter_p
 
         # WRAPPER (PlexedPiper)
@@ -124,7 +122,6 @@ workflow proteomics_msgfplus {
         Int? wrapper_ramGB
         String? wrapper_docker
         Int? wrapper_disk
-        Int? wrapper_preemptible = 2
         File? sd_fractions
         File? sd_references
         File? sd_samples
@@ -142,7 +139,7 @@ workflow proteomics_msgfplus {
             docker = msgf_docker,
             disks = msgf_disk,
             fasta_sequence_db = fasta_sequence_db,
-            preemptible = msgf_preemptible
+            preemptible = num_preemptible_attempts
     }
 
     scatter (i in range(length(raw_file))) {
@@ -152,7 +149,7 @@ workflow proteomics_msgfplus {
                 ramGB = masic_ramGB,
                 docker = masic_docker,
                 disks = masic_disk,
-                preemptible = masic_preemptible,
+                preemptible = num_preemptible_attempts,
                 raw_file = raw_file[i],
                 masic_parameter = masic_parameter,
                 quant_method = quant_method
@@ -164,7 +161,7 @@ workflow proteomics_msgfplus {
                 ramGB = msconvert_ramGB,
                 docker = msconvert_docker,
                 disks = msconvert_disk,
-                preemptible = msconvert_preemptible,
+                preemptible = num_preemptible_attempts,
                 raw_file = raw_file[i]
         }
 
@@ -174,7 +171,7 @@ workflow proteomics_msgfplus {
                 ramGB = msgf_ramGB,
                 docker = msgf_docker,
                 disks = msgf_disk,
-                preemptible = msgf_preemptible,
+                preemptible = num_preemptible_attempts,
                 input_mzml = msconvert.mzml,
                 fasta_sequence_db = fasta_sequence_db,
                 sequencedb_files = msgf_sequences.sequencedb_files,
@@ -187,7 +184,7 @@ workflow proteomics_msgfplus {
                 ramGB = msconvert_ramGB,
                 docker = msconvert_docker,
                 disks = msconvert_disk,
-                preemptible = msconvert_preemptible,
+                preemptible = num_preemptible_attempts,
                 input_mzml = msconvert.mzml,
                 input_mzid = msgf_tryptic.mzid
         }
@@ -198,7 +195,7 @@ workflow proteomics_msgfplus {
                 ramGB = msconvert_ramGB,
                 docker = ppm_errorcharter_docker,
                 disks = msconvert_disk,
-                preemptible = msconvert_preemptible,
+                preemptible = num_preemptible_attempts,
                 input_fixed_mzml = msconvert_mzrefiner.mzml_fixed,
                 input_mzid = msgf_tryptic.mzid
         }
@@ -209,7 +206,7 @@ workflow proteomics_msgfplus {
                 ramGB = msgf_ramGB,
                 docker = msgf_docker,
                 disks = msgf_disk,
-                preemptible = msgf_preemptible,
+                preemptible = num_preemptible_attempts,
                 input_fixed_mzml = msconvert_mzrefiner.mzml_fixed,
                 fasta_sequence_db = fasta_sequence_db,
                 sequencedb_files = msgf_sequences.sequencedb_files,
@@ -222,7 +219,7 @@ workflow proteomics_msgfplus {
                 ramGB = msconvert_ramGB,
                 docker = mzidtotsvconverter_docker,
                 disks = msconvert_disk,
-                preemptible = msconvert_preemptible,
+                preemptible = num_preemptible_attempts,
                 input_mzid_final = msgf_identification.mzid_final
         }
 
@@ -232,7 +229,7 @@ workflow proteomics_msgfplus {
                 ramGB = phrp_ramGB,
                 docker = phrp_docker,
                 disks = phrp_disk,
-                preemptible = phrp_preemptible,
+                preemptible = num_preemptible_attempts,
                 input_tsv = mzidtotsvconverter.tsv,
                 phrp_parameter_m = phrp_parameter_m,
                 phrp_parameter_t = phrp_parameter_t,
@@ -249,7 +246,7 @@ workflow proteomics_msgfplus {
                     ramGB = select_first([ascore_ramGB]),
                     docker = select_first([ascore_docker]),
                     disks = ascore_disk,
-                    preemptible = select_first([ascore_preemptible]),
+                    preemptible = num_preemptible_attempts,
                     input_syn = phrp.syn,
                     input_fixed_mzml = msgf_identification.rename_mzmlfixed,
                     ascore_parameter_p = select_first([ascore_parameter_p]),
@@ -266,7 +263,7 @@ workflow proteomics_msgfplus {
                 ramGB = select_first([wrapper_ramGB]),
                 docker = select_first([wrapper_docker]),
                 disks = wrapper_disk,
-                preemptible = select_first([wrapper_preemptible]),
+                preemptible = num_preemptible_attempts,
                 fractions = select_first([sd_fractions]),
                 references = select_first([sd_references]),
                 samples = select_first([sd_samples]),


### PR DESCRIPTION
@mihirsamdarshi , we have multiple pending updates:


This pull request standardizes and simplifies the handling of preemptible VM attempts across proteomics pipeline configurations and workflows. It consolidates multiple preemptible-related parameters into a single `num_preemptible_attempts` field for both MaxQuant and MSGFPlus pipelines, updates WDL workflow and task definitions to use this new parameter, and adds support for copying vial metadata files in the results copying script.

**Parameter Standardization and Simplification**

* Replaced multiple per-step preemptible parameters (e.g., `masic_preemptible`, `msconvert_preemptible`, etc.) with a single `proteomics_msgfplus.num_preemptible_attempts` field in all MSGFPlus configuration templates, simplifying configuration and reducing redundancy. [[1]](diffhunk://#diff-73c31ee5d8b7bc1165f46c98e99910d46059843e471f138c55d3f45a6c89676eL47-R47) [[2]](diffhunk://#diff-edad276038a319bba945250e7199834d1699ffcc85fb2a4bebff9a3e75841b73L50-R50) [[3]](diffhunk://#diff-3d1c216b7811e72e86d843bae0d565c50c7f8f2804b1699ec6ca4d7db6b08433L50-R50) [[4]](diffhunk://#diff-b80e6630fd82990dc5bc645a6809d81edd2aa32a757e14d8e99fdabed638a99cL50-R50) [[5]](diffhunk://#diff-bb80d286ec97c1967185505ccf5d4f9a458c7aa3b87a43f62a84d9d6660f8363L47-R47) [[6]](diffhunk://#diff-bd599242e9a30f97851ed9fc4ff22094b502e57f7238d48c5de8cb34d255161fL50-R50) [[7]](diffhunk://#diff-fd45c1209d218efc655192ca33b687bdc344da546fb685644c20593ae1922c74L50-R50) [[8]](diffhunk://#diff-6019f2b1989df9aa7e62a9d1ba8d91429aa14df9ee584f74003cdae4cef60203L50-R50) [[9]](diffhunk://#diff-c41366fc8bdf4216096f230dff09f7f63a60c3df5be3dac4f60df8218bf45b07L39-R39) [[10]](diffhunk://#diff-e35687812d43d53a7057187f231f3d6ba418cd960ac330e023c7e92bff92d173L44-R44) [[11]](diffhunk://#diff-ff56bdbf92a7c41b2efdce96ad6dd7933f0cd96efb7e154a61873daabf0968d8L44-R44) [[12]](diffhunk://#diff-57bed008955bec1aa187ae1e062d5e589e017c3dda180f3525175c21f5057844L44-R44) [[13]](diffhunk://#diff-dfd3cbf60be7f86b3ca6e4ff62a57a59e0e2b09bbf869fcc93958b01a50a9d11L47-R47) [[14]](diffhunk://#diff-024c58bfd73218c5063723b79427721ec00c22646f3985d79a518f3a39127594L50-R50) [[15]](diffhunk://#diff-50ca5a4888fd9de2589239bfa010da1bd413fdc8867fee104947f266feb5e720L50-R50) [[16]](diffhunk://#diff-4f890ceaed108b6f6a27593f80664816e387f817fa3548caba7deb0b0fe68ac3L50-R50)
* Added `proteomics_maxquant.num_preemptible_attempts` to MaxQuant configuration and updated the WDL workflow and task to use this parameter instead of hardcoding or omitting preemptible attempts. [[1]](diffhunk://#diff-107988d22c5f244b38c0e0c2aacd6e8fc063f0a518cfb4d09d279ed211c20345L8-R9) [[2]](diffhunk://#diff-58ebd84be5ee77a2eee0b665de5b763553fa0607b70b0127650785ca17417305R28) [[3]](diffhunk://#diff-58ebd84be5ee77a2eee0b665de5b763553fa0607b70b0127650785ca17417305L38-R40) [[4]](diffhunk://#diff-58ebd84be5ee77a2eee0b665de5b763553fa0607b70b0127650785ca17417305R50) [[5]](diffhunk://#diff-58ebd84be5ee77a2eee0b665de5b763553fa0607b70b0127650785ca17417305L100-R107)

**WDL Workflow Updates**

* Updated `proteomics_msgfplus.wdl` to remove individual preemptible parameters for each step and replace them with a single `num_preemptible_attempts` workflow input, which is then passed to all relevant tasks. [[1]](diffhunk://#diff-1290ce8518a431f0d0fe78f97a7412718f8a424f2ae4f6905c3afb1dc911c43bL56-R59) [[2]](diffhunk://#diff-1290ce8518a431f0d0fe78f97a7412718f8a424f2ae4f6905c3afb1dc911c43bL69-L84) [[3]](diffhunk://#diff-1290ce8518a431f0d0fe78f97a7412718f8a424f2ae4f6905c3afb1dc911c43bL105) [[4]](diffhunk://#diff-1290ce8518a431f0d0fe78f97a7412718f8a424f2ae4f6905c3afb1dc911c43bL119-L127) [[5]](diffhunk://#diff-1290ce8518a431f0d0fe78f97a7412718f8a424f2ae4f6905c3afb1dc911c43bL145-R142) [[6]](diffhunk://#diff-1290ce8518a431f0d0fe78f97a7412718f8a424f2ae4f6905c3afb1dc911c43bL155-R152) [[7]](diffhunk://#diff-1290ce8518a431f0d0fe78f97a7412718f8a424f2ae4f6905c3afb1dc911c43bL167-R164)

**Script Enhancement**

* Enhanced `copy_pipeline_results.py` to support an optional `--vial_metadata_path` argument, allowing validation and copying of a vial metadata file to the destination bucket before other operations. This includes dry-run support and error handling for missing files. [[1]](diffhunk://#diff-58ca1347d5d4a2495ac8bfcf3015c1948ab2fd755280b35d18495684eb8128b5R609-R615) [[2]](diffhunk://#diff-58ca1347d5d4a2495ac8bfcf3015c1948ab2fd755280b35d18495684eb8128b5R636-R663)