### PR TITLE
minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -793,7 +793,7 @@ Helps create parameter mapping files for the pipeline.
 #### `create_study_design.R`
 R script to create study design files from sample metadata.
 
-#### 8. `combine_study_design.R`
+#### `combine_study_design.R`
 Combines multiple study design files.
 
 #### `pp.R`

--- a/scripts/generate_file_manifest.py
+++ b/scripts/generate_file_manifest.py
@@ -1,4 +1,5 @@
 import argparse
+import hashlib
 import sys
 from base64 import b64decode
 from typing import Iterator, Tuple
@@ -56,10 +57,20 @@ def generate_manifest(path, outfile):
 
     for blob in blob_list:
         print(f"Processing {blob.name}")
-        if blob.name.endswith("/") or "file_manifest" in blob.name:
+        if (
+            blob.name.endswith("/")
+            or "file_manifest" in blob.name
+            or "/backup_annotation_fix/" in blob.name
+        ):
             continue
         relative_filename = blob.name.removeprefix(prefix)
-        decoded_hash = b64decode(blob.md5_hash).hex()
+
+        if blob.md5_hash:
+            decoded_hash = b64decode(blob.md5_hash).hex()
+        else:
+            print(f"No md5 metadata found for {blob.name}; computing md5 from blob contents")
+            decoded_hash = hashlib.md5(blob.download_as_bytes()).hexdigest()
+
         data += f"{relative_filename},{decoded_hash}\n"
         lines += 1
 


### PR DESCRIPTION
This pull request introduces improvements to the file manifest generation script and a minor documentation fix. The main update enhances the robustness of the manifest generation by ensuring that MD5 hashes are always available, even if not present in the blob metadata.

**Improvements to file manifest generation:**

* The script now computes the MD5 hash from blob contents using `hashlib` if the blob metadata does not include an MD5 hash, ensuring all files have a hash in the manifest. [[1]](diffhunk://#diff-34389e09919c4e0b7719f9e8328c4b54eba16de5eb9f0b961de2f9337a423347R2) [[2]](diffhunk://#diff-34389e09919c4e0b7719f9e8328c4b54eba16de5eb9f0b961de2f9337a423347L59-R73)
* Added a filter to skip blobs in the `/backup_annotation_fix/` directory when generating the manifest.

**Documentation update:**

* Fixed a formatting issue in `README.md` by removing an incorrect section number from the `combine_study_design.R` heading.